### PR TITLE
Añadida documentación de validación SHACL en inglés y español

### DIFF
--- a/docs/img/dge_shacl.en.drawio
+++ b/docs/img/dge_shacl.en.drawio
@@ -1,0 +1,219 @@
+<mxfile host="Electron" agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/26.2.2 Chrome/134.0.6998.178 Electron/35.1.2 Safari/537.36" version="26.2.2">
+  <diagram name="Page-1" id="HUJMsCtopg-WY_ma1BH4">
+    <mxGraphModel dx="5130" dy="2963" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="C39UIkgcu5n6xboTU2DO-69" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#C9E2DF;strokeColor=#82b366;strokeWidth=5;dashed=1;dashPattern=1 2;fillOpacity=20;" vertex="1" parent="1">
+          <mxGeometry x="2946" y="400" width="304" height="164" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-70" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFCCCC;strokeColor=#FF6666;strokeWidth=5;dashed=1;dashPattern=1 2;fillOpacity=20;" vertex="1" parent="1">
+          <mxGeometry x="2946" y="570" width="304" height="160" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-71" value="" style="shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;imageAspect=0;editableCssRules=.*;image=data:image/svg+xml,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjEgMSAyMiAyMiIgaGVpZ2h0PSI3MzMuMzMzMzMzMzMzMzMzNCIgd2lkdGg9IjczMy4zMzMzMzMzMzMzMzM0Ij48cGF0aCBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZT0iI2RmNmMwYyIgZmlsbD0iI2ZiZjJlOSIgZD0iTTEyIDJDNy4yODYgMiA0LjkyOSAyIDMuNDY0IDMuNDY0IDIgNC45MyAyIDcuMjg2IDIgMTJzMCA3LjA3MSAxLjQ2NCA4LjUzNUM0LjkzIDIyIDcuMjg2IDIyIDEyIDIyczcuMDcxIDAgOC41MzUtMS40NjVDMjIgMTkuMDcyIDIyIDE2LjcxNCAyMiAxMnMwLTcuMDcxLTEuNDY1LTguNTM2QzE5LjA3MiAyIDE2LjcxNCAyIDEyIDJaIiBvcGFjaXR5PSIuNSIvPjxwYXRoIGZpbGw9IiNkZjZjMGMiIGQ9Ik0xMiA2LjI1YS43NS43NSAwIDAgMSAuNzUuNzV2NmEuNzUuNzUgMCAwIDEtMS41IDBWN2EuNzUuNzUgMCAwIDEgLjc1LS43NU0xMiAxN2ExIDEgMCAxIDAgMC0yIDEgMSAwIDAgMCAwIDIiLz48L3N2Zz4=;" vertex="1" parent="1">
+          <mxGeometry x="2965.5" y="573" width="65" height="65" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-72" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="350" y="280" width="740" height="570" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-73" value="" style="group" vertex="1" connectable="0" parent="C39UIkgcu5n6xboTU2DO-72">
+          <mxGeometry width="740" height="570" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-74" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#C9E2DF;fontSize=25;verticalAlign=top;fontStyle=1;fontFamily=Poppins;strokeColor=#00A99D;strokeWidth=3;fillOpacity=75;fontColor=#10739E;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-73">
+          <mxGeometry y="37" width="740" height="533" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-75" value="&lt;b&gt;Data Graph&lt;/b&gt;&lt;b style=&quot;font-size: 40px;&quot;&gt;&lt;font data-font-src=&quot;https://fonts.googleapis.com/css?family=Source+Sans+Pro&quot; style=&quot;font-size: 40px;&quot;&gt;&lt;/font&gt;&lt;/b&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=1;fontColor=#EEEEEE;strokeWidth=2;fontSize=40;fontFamily=Poppins;strokeColor=none;fillOpacity=100;fillColor=#154481;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-73">
+          <mxGeometry x="170.74999999999977" y="-10" width="398.5" height="100" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-76" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-73">
+          <mxGeometry x="140" y="170" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-77" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-73">
+          <mxGeometry x="310" y="360" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-78" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-73">
+          <mxGeometry x="410" y="160" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-79" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-73">
+          <mxGeometry x="250" y="229" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-80" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-73">
+          <mxGeometry x="80" y="360" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-81" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-73">
+          <mxGeometry x="540" y="420" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-82" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-73">
+          <mxGeometry x="470" y="278.5" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-83" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-73">
+          <mxGeometry x="630" y="160" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-84" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-73">
+          <mxGeometry x="250" y="120" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-85" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-73">
+          <mxGeometry x="191" y="470" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-86" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-73">
+          <mxGeometry x="191" y="340" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-87" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-73">
+          <mxGeometry x="397" y="450" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-88" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-73">
+          <mxGeometry x="600" y="300" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-89" style="rounded=1;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeColor=#154481;strokeWidth=15;endArrow=block;endFill=1;flowAnimation=1;startFill=0;shadow=0;jumpStyle=none;dashed=1;dashPattern=1 1;edgeStyle=orthogonalEdgeStyle;curved=1;endSize=7;startSize=7;opacity=90;" edge="1" parent="1" source="C39UIkgcu5n6xboTU2DO-74" target="C39UIkgcu5n6xboTU2DO-98">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-90" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="2350" y="450" width="320" height="240" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-91" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;shadow=0;dashed=1;dashPattern=1 1;opacity=90;strokeColor=#154481;strokeWidth=15;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=11;fontColor=default;labelBackgroundColor=default;jumpStyle=none;startFill=0;startSize=7;endArrow=block;endFill=1;endSize=7;flowAnimation=1;curved=1;" edge="1" parent="C39UIkgcu5n6xboTU2DO-90" source="C39UIkgcu5n6xboTU2DO-92">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="540" y="120" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-92" value="" style="rounded=1;whiteSpace=wrap;html=1;gradientColor=none;strokeColor=#154481;strokeWidth=5;fillColor=#00A99D;fillOpacity=20;dashed=1;container=0;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-90">
+          <mxGeometry width="320" height="240" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-93" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;container=0;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-90">
+          <mxGeometry x="160" y="50" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-94" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;container=0;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-90">
+          <mxGeometry x="247" y="140" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-95" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;container=0;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-90">
+          <mxGeometry x="41" y="160" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-96" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;container=0;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-90">
+          <mxGeometry x="41" y="30" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-97" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="1350" y="270" width="740" height="580" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-98" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#C9E2DF;fontSize=25;verticalAlign=top;fontStyle=1;fontFamily=Poppins;strokeColor=#00A99D;strokeWidth=3;fillOpacity=75;fontColor=#10739E;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-97">
+          <mxGeometry y="47" width="740" height="533" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-99" value="&lt;b&gt;Validation nodes&lt;/b&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=1;fontColor=#EEEEEE;strokeWidth=2;fontSize=40;fontFamily=Poppins;strokeColor=none;fillOpacity=100;fillColor=#154481;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-97">
+          <mxGeometry x="170.75" width="398.5" height="100" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-100" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-97">
+          <mxGeometry x="140" y="180" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-101" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-97">
+          <mxGeometry x="410" y="170" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-102" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-97">
+          <mxGeometry x="250" y="239" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-103" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-97">
+          <mxGeometry x="80" y="370" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-104" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-97">
+          <mxGeometry x="540" y="430" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-105" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-97">
+          <mxGeometry x="470" y="288.5" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-106" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-97">
+          <mxGeometry x="630" y="170" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-107" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-97">
+          <mxGeometry x="250" y="130" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-108" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-97">
+          <mxGeometry x="600" y="310" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-109" value="" style="group;glass=0;" vertex="1" connectable="0" parent="C39UIkgcu5n6xboTU2DO-97">
+          <mxGeometry x="150" y="320" width="320" height="240" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-110" value="" style="rounded=1;whiteSpace=wrap;html=1;gradientColor=none;strokeColor=#154481;strokeWidth=5;fillColor=#00A99D;fillOpacity=20;dashed=1;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-109">
+          <mxGeometry width="320" height="240" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-111" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-109">
+          <mxGeometry x="160" y="50" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-112" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-109">
+          <mxGeometry x="247" y="140" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-113" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-109">
+          <mxGeometry x="41" y="160" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-114" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" vertex="1" parent="C39UIkgcu5n6xboTU2DO-109">
+          <mxGeometry x="41" y="30" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-115" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.005;entryY=0.552;entryDx=0;entryDy=0;entryPerimeter=0;shadow=0;dashed=1;dashPattern=1 1;opacity=90;strokeColor=#154481;strokeWidth=15;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=11;fontColor=default;labelBackgroundColor=default;jumpStyle=none;startFill=0;startSize=7;endArrow=block;endFill=1;endSize=7;flowAnimation=1;curved=1;" edge="1" parent="1" source="C39UIkgcu5n6xboTU2DO-98" target="C39UIkgcu5n6xboTU2DO-92">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-116" value="&lt;b&gt;SHACL constraints&lt;/b&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=1;fontColor=#EEEEEE;strokeWidth=2;fontSize=40;fontFamily=Poppins;strokeColor=none;fillOpacity=100;fillColor=#154481;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;" vertex="1" parent="1">
+          <mxGeometry x="2590" y="270" width="398.5" height="100" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-117" style="rounded=1;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;shadow=0;dashed=1;dashPattern=1 1;opacity=90;strokeColor=#154481;strokeWidth=15;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=11;fontColor=default;labelBackgroundColor=default;jumpStyle=none;startFill=0;startSize=7;endArrow=block;endFill=1;endSize=7;flowAnimation=1;edgeStyle=orthogonalEdgeStyle;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" edge="1" parent="1" source="C39UIkgcu5n6xboTU2DO-69" target="C39UIkgcu5n6xboTU2DO-118">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="3250" y="480" />
+              <mxPoint x="3280" y="480" />
+              <mxPoint x="3280" y="425" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-118" value="&lt;b&gt;Conforms to&lt;/b&gt;&lt;div&gt;&lt;b&gt;DCAT-AP-ES&lt;/b&gt;&lt;/div&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=1;strokeWidth=6;fontSize=28;fontFamily=Poppins;strokeColor=#82B366;fillOpacity=100;fillColor=#d5e8d4;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontColor=#82B366;" vertex="1" parent="1">
+          <mxGeometry x="3390" y="330" width="280" height="190" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-119" value="&lt;b&gt;&lt;font style=&quot;color: rgb(184, 84, 80);&quot;&gt;Violations &amp;amp;&lt;/font&gt;&lt;/b&gt;&lt;div&gt;&lt;b&gt;&lt;font style=&quot;color: rgb(223, 108, 12);&quot;&gt;recommendations&lt;/font&gt;&lt;/b&gt;&lt;/div&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=1;strokeWidth=6;fontSize=28;fontFamily=Poppins;strokeColor=#b85450;fillOpacity=100;fillColor=#f8cecc;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;" vertex="1" parent="1">
+          <mxGeometry x="3390" y="600" width="280" height="190" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-120" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;shadow=0;dashed=1;dashPattern=1 1;opacity=90;strokeColor=#154481;strokeWidth=15;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=11;fontColor=default;labelBackgroundColor=default;jumpStyle=none;startFill=0;startSize=7;endArrow=block;endFill=1;endSize=7;flowAnimation=1;curved=1;" edge="1" parent="1" source="C39UIkgcu5n6xboTU2DO-70" target="C39UIkgcu5n6xboTU2DO-119">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-121" value="" style="shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;imageAspect=0;editableCssRules=.*;image=data:image/svg+xml,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjEgMSAyMiAyMiIgaGVpZ2h0PSI3MzMuMzMzMzMzMzMzMzMzNCIgd2lkdGg9IjczMy4zMzMzMzMzMzMzMzM0Ij48cGF0aCBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZT0iI2RmNmMwYyIgZmlsbD0iI2ZiZjJlOSIgZD0iTTEyIDJDNy4yODYgMiA0LjkyOSAyIDMuNDY0IDMuNDY0IDIgNC45MyAyIDcuMjg2IDIgMTJzMCA3LjA3MSAxLjQ2NCA4LjUzNUM0LjkzIDIyIDcuMjg2IDIyIDEyIDIyczcuMDcxIDAgOC41MzUtMS40NjVDMjIgMTkuMDcyIDIyIDE2LjcxNCAyMiAxMnMwLTcuMDcxLTEuNDY1LTguNTM2QzE5LjA3MiAyIDE2LjcxNCAyIDEyIDJaIiBvcGFjaXR5PSIuNSIvPjxwYXRoIGZpbGw9IiNkZjZjMGMiIGQ9Ik0xMiA2LjI1YS43NS43NSAwIDAgMSAuNzUuNzV2NmEuNzUuNzUgMCAwIDEtMS41IDBWN2EuNzUuNzUgMCAwIDEgLjc1LS43NU0xMiAxN2ExIDEgMCAxIDAgMC0yIDEgMSAwIDAgMCAwIDIiLz48L3N2Zz4=;" vertex="1" parent="1">
+          <mxGeometry x="3065.5" y="655" width="65" height="65" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-122" value="" style="shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;imageAspect=0;editableCssRules=.*;image=data:image/svg+xml,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjEgMSAyMiAyMiIgaGVpZ2h0PSI3MzMuMzMzMzMzMzMzMzMzNCIgd2lkdGg9IjczMy4zMzMzMzMzMzMzMzM0Ij4mI3hhOyAgJiN4YTsgIDxwYXRoIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlPSIjODJCMzY2IiBmaWxsPSIjRDVFOEQ0IiBkPSJNMTIgMjJDNy4yODU5NSAyMiA0LjkyODkzIDIyIDMuNDY0NDcgMjAuNTM1NUMyIDE5LjA3MTEgMiAxNi43MTQgMiAxMkMyIDcuMjg1OTUgMiA0LjkyODkzIDMuNDY0NDcgMy40NjQ0N0M0LjkyODkzIDIgNy4yODU5NSAyIDEyIDJDMTYuNzE0IDIgMTkuMDcxMSAyIDIwLjUzNTUgMy40NjQ0N0MyMiA0LjkyODkzIDIyIDcuMjg1OTUgMjIgMTJDMjIgMTYuNzE0IDIyIDE5LjA3MTEgMjAuNTM1NSAyMC41MzU1QzE5LjA3MTEgMjIgMTYuNzE0IDIyIDEyIDIyWiIgb3BhY2l0eT0iMC41Ii8+JiN4YTsgICYjeGE7ICAmI3hhOyAgPHBhdGggZmlsbD0iIzgyQjM2NiIgZD0iTTE2LjAzMDMgOC45Njk2N0MxNi4zMjMyIDkuMjYyNTYgMTYuMzIzMiA5LjczNzQ0IDE2LjAzMDMgMTAuMDMwM0wxMS4wMzAzIDE1LjAzMDNDMTAuNzM3NCAxNS4zMjMyIDEwLjI2MjYgMTUuMzIzMiA5Ljk2OTY3IDE1LjAzMDNMNy45Njk2NyAxMy4wMzAzQzcuNjc2NzggMTIuNzM3NCA3LjY3Njc4IDEyLjI2MjYgNy45Njk2NyAxMS45Njk3QzguMjYyNTYgMTEuNjc2OCA4LjczNzQ0IDExLjY3NjggOS4wMzAzMyAxMS45Njk3TDEwLjUgMTMuNDM5M0wxNC45Njk3IDguOTY5NjdDMTUuMjYyNiA4LjY3Njc4IDE1LjczNzQgOC42NzY3OCAxNi4wMzAzIDguOTY5NjdaIi8+JiN4YTs8L3N2Zz4=;container=0;" vertex="1" parent="1">
+          <mxGeometry x="3065.5" y="410" width="65" height="65" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-123" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;container=0;" vertex="1" parent="1">
+          <mxGeometry x="2885.5" y="417.5" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-124" value="" style="shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;imageAspect=0;editableCssRules=.*;image=data:image/svg+xml,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjEgMSAyMiAyMiIgaGVpZ2h0PSI3MzMuMzMzMzMzMzMzMzMzNCIgd2lkdGg9IjczMy4zMzMzMzMzMzMzMzM0Ij4mI3hhOyAgJiN4YTsgIDxwYXRoIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlPSIjODJCMzY2IiBmaWxsPSIjRDVFOEQ0IiBkPSJNMTIgMjJDNy4yODU5NSAyMiA0LjkyODkzIDIyIDMuNDY0NDcgMjAuNTM1NUMyIDE5LjA3MTEgMiAxNi43MTQgMiAxMkMyIDcuMjg1OTUgMiA0LjkyODkzIDMuNDY0NDcgMy40NjQ0N0M0LjkyODkzIDIgNy4yODU5NSAyIDEyIDJDMTYuNzE0IDIgMTkuMDcxMSAyIDIwLjUzNTUgMy40NjQ0N0MyMiA0LjkyODkzIDIyIDcuMjg1OTUgMjIgMTJDMjIgMTYuNzE0IDIyIDE5LjA3MTEgMjAuNTM1NSAyMC41MzU1QzE5LjA3MTEgMjIgMTYuNzE0IDIyIDEyIDIyWiIgb3BhY2l0eT0iMC41Ii8+JiN4YTsgICYjeGE7ICAmI3hhOyAgPHBhdGggZmlsbD0iIzgyQjM2NiIgZD0iTTE2LjAzMDMgOC45Njk2N0MxNi4zMjMyIDkuMjYyNTYgMTYuMzIzMiA5LjczNzQ0IDE2LjAzMDMgMTAuMDMwM0wxMS4wMzAzIDE1LjAzMDNDMTAuNzM3NCAxNS4zMjMyIDEwLjI2MjYgMTUuMzIzMiA5Ljk2OTY3IDE1LjAzMDNMNy45Njk2NyAxMy4wMzAzQzcuNjc2NzggMTIuNzM3NCA3LjY3Njc4IDEyLjI2MjYgNy45Njk2NyAxMS45Njk3QzguMjYyNTYgMTEuNjc2OCA4LjczNzQ0IDExLjY3NjggOS4wMzAzMyAxMS45Njk3TDEwLjUgMTMuNDM5M0wxNC45Njk3IDguOTY5NjdDMTUuMjYyNiA4LjY3Njc4IDE1LjczNzQgOC42NzY3OCAxNi4wMzAzIDguOTY5NjdaIi8+JiN4YTs8L3N2Zz4=;container=0;" vertex="1" parent="1">
+          <mxGeometry x="2965.5" y="410" width="65" height="65" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-125" value="" style="shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;imageAspect=0;editableCssRules=.*;image=data:image/svg+xml,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjEgMSAyMiAyMiIgaGVpZ2h0PSI3MzMuMzMzMzMzMzMzMzMzNCIgd2lkdGg9IjczMy4zMzMzMzMzMzMzMzM0Ij4mI3hhOyAgJiN4YTsgIDxwYXRoIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlPSIjODJCMzY2IiBmaWxsPSIjRDVFOEQ0IiBkPSJNMTIgMjJDNy4yODU5NSAyMiA0LjkyODkzIDIyIDMuNDY0NDcgMjAuNTM1NUMyIDE5LjA3MTEgMiAxNi43MTQgMiAxMkMyIDcuMjg1OTUgMiA0LjkyODkzIDMuNDY0NDcgMy40NjQ0N0M0LjkyODkzIDIgNy4yODU5NSAyIDEyIDJDMTYuNzE0IDIgMTkuMDcxMSAyIDIwLjUzNTUgMy40NjQ0N0MyMiA0LjkyODkzIDIyIDcuMjg1OTUgMjIgMTJDMjIgMTYuNzE0IDIyIDE5LjA3MTEgMjAuNTM1NSAyMC41MzU1QzE5LjA3MTEgMjIgMTYuNzE0IDIyIDEyIDIyWiIgb3BhY2l0eT0iMC41Ii8+JiN4YTsgICYjeGE7ICAmI3hhOyAgPHBhdGggZmlsbD0iIzgyQjM2NiIgZD0iTTE2LjAzMDMgOC45Njk2N0MxNi4zMjMyIDkuMjYyNTYgMTYuMzIzMiA5LjczNzQ0IDE2LjAzMDMgMTAuMDMwM0wxMS4wMzAzIDE1LjAzMDNDMTAuNzM3NCAxNS4zMjMyIDEwLjI2MjYgMTUuMzIzMiA5Ljk2OTY3IDE1LjAzMDNMNy45Njk2NyAxMy4wMzAzQzcuNjc2NzggMTIuNzM3NCA3LjY3Njc4IDEyLjI2MjYgNy45Njk2NyAxMS45Njk3QzguMjYyNTYgMTEuNjc2OCA4LjczNzQ0IDExLjY3NjggOS4wMzAzMyAxMS45Njk3TDEwLjUgMTMuNDM5M0wxNC45Njk3IDguOTY5NjdDMTUuMjYyNiA4LjY3Njc4IDE1LjczNzQgOC42NzY3OCAxNi4wMzAzIDguOTY5NjdaIi8+JiN4YTs8L3N2Zz4=;container=0;" vertex="1" parent="1">
+          <mxGeometry x="3168" y="410" width="65" height="65" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-126" value="" style="shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;imageAspect=0;editableCssRules=.*;image=data:image/svg+xml,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjEgMSAyMiAyMiIgaGVpZ2h0PSI3MzMuMzMzMzMzMzMzMzMzNCIgd2lkdGg9IjczMy4zMzMzMzMzMzMzMzM0Ij4mI3hhOyAgJiN4YTsgIDxwYXRoIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlPSIjODJCMzY2IiBmaWxsPSIjRDVFOEQ0IiBkPSJNMTIgMjJDNy4yODU5NSAyMiA0LjkyODkzIDIyIDMuNDY0NDcgMjAuNTM1NUMyIDE5LjA3MTEgMiAxNi43MTQgMiAxMkMyIDcuMjg1OTUgMiA0LjkyODkzIDMuNDY0NDcgMy40NjQ0N0M0LjkyODkzIDIgNy4yODU5NSAyIDEyIDJDMTYuNzE0IDIgMTkuMDcxMSAyIDIwLjUzNTUgMy40NjQ0N0MyMiA0LjkyODkzIDIyIDcuMjg1OTUgMjIgMTJDMjIgMTYuNzE0IDIyIDE5LjA3MTEgMjAuNTM1NSAyMC41MzU1QzE5LjA3MTEgMjIgMTYuNzE0IDIyIDEyIDIyWiIgb3BhY2l0eT0iMC41Ii8+JiN4YTsgICYjeGE7ICAmI3hhOyAgPHBhdGggZmlsbD0iIzgyQjM2NiIgZD0iTTE2LjAzMDMgOC45Njk2N0MxNi4zMjMyIDkuMjYyNTYgMTYuMzIzMiA5LjczNzQ0IDE2LjAzMDMgMTAuMDMwM0wxMS4wMzAzIDE1LjAzMDNDMTAuNzM3NCAxNS4zMjMyIDEwLjI2MjYgMTUuMzIzMiA5Ljk2OTY3IDE1LjAzMDNMNy45Njk2NyAxMy4wMzAzQzcuNjc2NzggMTIuNzM3NCA3LjY3Njc4IDEyLjI2MjYgNy45Njk2NyAxMS45Njk3QzguMjYyNTYgMTEuNjc2OCA4LjczNzQ0IDExLjY3NjggOS4wMzAzMyAxMS45Njk3TDEwLjUgMTMuNDM5M0wxNC45Njk3IDguOTY5NjdDMTUuMjYyNiA4LjY3Njc4IDE1LjczNzQgOC42NzY3OCAxNi4wMzAzIDguOTY5NjdaIi8+JiN4YTs8L3N2Zz4=;container=0;" vertex="1" parent="1">
+          <mxGeometry x="3065.5" y="492" width="65" height="65" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-127" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;container=0;" vertex="1" parent="1">
+          <mxGeometry x="2885.5" y="499.5" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-128" value="" style="shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;imageAspect=0;editableCssRules=.*;image=data:image/svg+xml,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjEgMSAyMiAyMiIgaGVpZ2h0PSI3MzMuMzMzMzMzMzMzMzMzNCIgd2lkdGg9IjczMy4zMzMzMzMzMzMzMzM0Ij4mI3hhOyAgJiN4YTsgIDxwYXRoIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlPSIjODJCMzY2IiBmaWxsPSIjRDVFOEQ0IiBkPSJNMTIgMjJDNy4yODU5NSAyMiA0LjkyODkzIDIyIDMuNDY0NDcgMjAuNTM1NUMyIDE5LjA3MTEgMiAxNi43MTQgMiAxMkMyIDcuMjg1OTUgMiA0LjkyODkzIDMuNDY0NDcgMy40NjQ0N0M0LjkyODkzIDIgNy4yODU5NSAyIDEyIDJDMTYuNzE0IDIgMTkuMDcxMSAyIDIwLjUzNTUgMy40NjQ0N0MyMiA0LjkyODkzIDIyIDcuMjg1OTUgMjIgMTJDMjIgMTYuNzE0IDIyIDE5LjA3MTEgMjAuNTM1NSAyMC41MzU1QzE5LjA3MTEgMjIgMTYuNzE0IDIyIDEyIDIyWiIgb3BhY2l0eT0iMC41Ii8+JiN4YTsgICYjeGE7ICAmI3hhOyAgPHBhdGggZmlsbD0iIzgyQjM2NiIgZD0iTTE2LjAzMDMgOC45Njk2N0MxNi4zMjMyIDkuMjYyNTYgMTYuMzIzMiA5LjczNzQ0IDE2LjAzMDMgMTAuMDMwM0wxMS4wMzAzIDE1LjAzMDNDMTAuNzM3NCAxNS4zMjMyIDEwLjI2MjYgMTUuMzIzMiA5Ljk2OTY3IDE1LjAzMDNMNy45Njk2NyAxMy4wMzAzQzcuNjc2NzggMTIuNzM3NCA3LjY3Njc4IDEyLjI2MjYgNy45Njk2NyAxMS45Njk3QzguMjYyNTYgMTEuNjc2OCA4LjczNzQ0IDExLjY3NjggOS4wMzAzMyAxMS45Njk3TDEwLjUgMTMuNDM5M0wxNC45Njk3IDguOTY5NjdDMTUuMjYyNiA4LjY3Njc4IDE1LjczNzQgOC42NzY3OCAxNi4wMzAzIDguOTY5NjdaIi8+JiN4YTs8L3N2Zz4=;container=0;" vertex="1" parent="1">
+          <mxGeometry x="2965.5" y="492" width="65" height="65" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-129" value="" style="shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;imageAspect=0;editableCssRules=.*;image=data:image/svg+xml,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjEgMSAyMiAyMiIgaGVpZ2h0PSI3MzMuMzMzMzMzMzMzMzMzNCIgd2lkdGg9IjczMy4zMzMzMzMzMzMzMzM0Ij4mI3hhOyAgJiN4YTsgIDxwYXRoIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlPSIjODJCMzY2IiBmaWxsPSIjRDVFOEQ0IiBkPSJNMTIgMjJDNy4yODU5NSAyMiA0LjkyODkzIDIyIDMuNDY0NDcgMjAuNTM1NUMyIDE5LjA3MTEgMiAxNi43MTQgMiAxMkMyIDcuMjg1OTUgMiA0LjkyODkzIDMuNDY0NDcgMy40NjQ0N0M0LjkyODkzIDIgNy4yODU5NSAyIDEyIDJDMTYuNzE0IDIgMTkuMDcxMSAyIDIwLjUzNTUgMy40NjQ0N0MyMiA0LjkyODkzIDIyIDcuMjg1OTUgMjIgMTJDMjIgMTYuNzE0IDIyIDE5LjA3MTEgMjAuNTM1NSAyMC41MzU1QzE5LjA3MTEgMjIgMTYuNzE0IDIyIDEyIDIyWiIgb3BhY2l0eT0iMC41Ii8+JiN4YTsgICYjeGE7ICAmI3hhOyAgPHBhdGggZmlsbD0iIzgyQjM2NiIgZD0iTTE2LjAzMDMgOC45Njk2N0MxNi4zMjMyIDkuMjYyNTYgMTYuMzIzMiA5LjczNzQ0IDE2LjAzMDMgMTAuMDMwM0wxMS4wMzAzIDE1LjAzMDNDMTAuNzM3NCAxNS4zMjMyIDEwLjI2MjYgMTUuMzIzMiA5Ljk2OTY3IDE1LjAzMDNMNy45Njk2NyAxMy4wMzAzQzcuNjc2NzggMTIuNzM3NCA3LjY3Njc4IDEyLjI2MjYgNy45Njk2NyAxMS45Njk3QzguMjYyNTYgMTEuNjc2OCA4LjczNzQ0IDExLjY3NjggOS4wMzAzMyAxMS45Njk3TDEwLjUgMTMuNDM5M0wxNC45Njk3IDguOTY5NjdDMTUuMjYyNiA4LjY3Njc4IDE1LjczNzQgOC42NzY3OCAxNi4wMzAzIDguOTY5NjdaIi8+JiN4YTs8L3N2Zz4=;container=0;" vertex="1" parent="1">
+          <mxGeometry x="3168" y="492" width="65" height="65" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-130" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;container=0;" vertex="1" parent="1">
+          <mxGeometry x="2885.5" y="580.5" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-131" value="" style="shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;imageAspect=0;editableCssRules=.*;image=data:image/svg+xml,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjEgMSAyMiAyMiIgaGVpZ2h0PSI3MzMuMzMzMzMzMzMzMzMzNCIgd2lkdGg9IjczMy4zMzMzMzMzMzMzMzM0Ij48cGF0aCBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZT0iI0I4NTQ1MCIgZmlsbD0iI0Y4Q0VDQyIgZD0iTTEyIDIyYy00LjcxNCAwLTcuMDcxIDAtOC41MzYtMS40NjVDMiAxOS4wNzIgMiAxNi43MTQgMiAxMnMwLTcuMDcxIDEuNDY0LTguNTM2QzQuOTMgMiA3LjI4NiAyIDEyIDJzNy4wNzEgMCA4LjUzNSAxLjQ2NEMyMiA0LjkzIDIyIDcuMjg2IDIyIDEyczAgNy4wNzEtMS40NjUgOC41MzVDMTkuMDcyIDIyIDE2LjcxNCAyMiAxMiAyMloiIG9wYWNpdHk9Ii41Ii8+LyZndDs8cGF0aCBmaWxsPSIjQjg1NDUwIiBkPSJNOC45NyA4Ljk3YS43NS43NSAwIDAgMSAxLjA2IDBMMTIgMTAuOTRsMS45Ny0xLjk3YS43NS43NSAwIDEgMSAxLjA2IDEuMDZMMTMuMDYgMTJsMS45NyAxLjk3YS43NS43NSAwIDEgMS0xLjA2IDEuMDZMMTIgMTMuMDZsLTEuOTcgMS45N2EuNzUuNzUgMCAwIDEtMS4wNi0xLjA2TDEwLjk0IDEybC0xLjk3LTEuOTdhLjc1Ljc1IDAgMCAxIDAtMS4wNiIvPjwvc3ZnPg==;container=0;" vertex="1" parent="1">
+          <mxGeometry x="3065.5" y="573" width="65" height="65" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-132" value="" style="shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;imageAspect=0;editableCssRules=.*;image=data:image/svg+xml,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjEgMSAyMiAyMiIgaGVpZ2h0PSI3MzMuMzMzMzMzMzMzMzMzNCIgd2lkdGg9IjczMy4zMzMzMzMzMzMzMzM0Ij4mI3hhOyAgJiN4YTsgIDxwYXRoIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlPSIjODJCMzY2IiBmaWxsPSIjRDVFOEQ0IiBkPSJNMTIgMjJDNy4yODU5NSAyMiA0LjkyODkzIDIyIDMuNDY0NDcgMjAuNTM1NUMyIDE5LjA3MTEgMiAxNi43MTQgMiAxMkMyIDcuMjg1OTUgMiA0LjkyODkzIDMuNDY0NDcgMy40NjQ0N0M0LjkyODkzIDIgNy4yODU5NSAyIDEyIDJDMTYuNzE0IDIgMTkuMDcxMSAyIDIwLjUzNTUgMy40NjQ0N0MyMiA0LjkyODkzIDIyIDcuMjg1OTUgMjIgMTJDMjIgMTYuNzE0IDIyIDE5LjA3MTEgMjAuNTM1NSAyMC41MzU1QzE5LjA3MTEgMjIgMTYuNzE0IDIyIDEyIDIyWiIgb3BhY2l0eT0iMC41Ii8+JiN4YTsgICYjeGE7ICAmI3hhOyAgPHBhdGggZmlsbD0iIzgyQjM2NiIgZD0iTTE2LjAzMDMgOC45Njk2N0MxNi4zMjMyIDkuMjYyNTYgMTYuMzIzMiA5LjczNzQ0IDE2LjAzMDMgMTAuMDMwM0wxMS4wMzAzIDE1LjAzMDNDMTAuNzM3NCAxNS4zMjMyIDEwLjI2MjYgMTUuMzIzMiA5Ljk2OTY3IDE1LjAzMDNMNy45Njk2NyAxMy4wMzAzQzcuNjc2NzggMTIuNzM3NCA3LjY3Njc4IDEyLjI2MjYgNy45Njk2NyAxMS45Njk3QzguMjYyNTYgMTEuNjc2OCA4LjczNzQ0IDExLjY3NjggOS4wMzAzMyAxMS45Njk3TDEwLjUgMTMuNDM5M0wxNC45Njk3IDguOTY5NjdDMTUuMjYyNiA4LjY3Njc4IDE1LjczNzQgOC42NzY3OCAxNi4wMzAzIDguOTY5NjdaIi8+JiN4YTs8L3N2Zz4=;container=0;" vertex="1" parent="1">
+          <mxGeometry x="3168" y="573" width="65" height="65" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-133" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;container=0;" vertex="1" parent="1">
+          <mxGeometry x="2885.5" y="662.5" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-134" value="" style="shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;imageAspect=0;editableCssRules=.*;image=data:image/svg+xml,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjEgMSAyMiAyMiIgaGVpZ2h0PSI3MzMuMzMzMzMzMzMzMzMzNCIgd2lkdGg9IjczMy4zMzMzMzMzMzMzMzM0Ij4mI3hhOyAgJiN4YTsgIDxwYXRoIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlPSIjODJCMzY2IiBmaWxsPSIjRDVFOEQ0IiBkPSJNMTIgMjJDNy4yODU5NSAyMiA0LjkyODkzIDIyIDMuNDY0NDcgMjAuNTM1NUMyIDE5LjA3MTEgMiAxNi43MTQgMiAxMkMyIDcuMjg1OTUgMiA0LjkyODkzIDMuNDY0NDcgMy40NjQ0N0M0LjkyODkzIDIgNy4yODU5NSAyIDEyIDJDMTYuNzE0IDIgMTkuMDcxMSAyIDIwLjUzNTUgMy40NjQ0N0MyMiA0LjkyODkzIDIyIDcuMjg1OTUgMjIgMTJDMjIgMTYuNzE0IDIyIDE5LjA3MTEgMjAuNTM1NSAyMC41MzU1QzE5LjA3MTEgMjIgMTYuNzE0IDIyIDEyIDIyWiIgb3BhY2l0eT0iMC41Ii8+JiN4YTsgICYjeGE7ICAmI3hhOyAgPHBhdGggZmlsbD0iIzgyQjM2NiIgZD0iTTE2LjAzMDMgOC45Njk2N0MxNi4zMjMyIDkuMjYyNTYgMTYuMzIzMiA5LjczNzQ0IDE2LjAzMDMgMTAuMDMwM0wxMS4wMzAzIDE1LjAzMDNDMTAuNzM3NCAxNS4zMjMyIDEwLjI2MjYgMTUuMzIzMiA5Ljk2OTY3IDE1LjAzMDNMNy45Njk2NyAxMy4wMzAzQzcuNjc2NzggMTIuNzM3NCA3LjY3Njc4IDEyLjI2MjYgNy45Njk2NyAxMS45Njk3QzguMjYyNTYgMTEuNjc2OCA4LjczNzQ0IDExLjY3NjggOS4wMzAzMyAxMS45Njk3TDEwLjUgMTMuNDM5M0wxNC45Njk3IDguOTY5NjdDMTUuMjYyNiA4LjY3Njc4IDE1LjczNzQgOC42NzY3OCAxNi4wMzAzIDguOTY5NjdaIi8+JiN4YTs8L3N2Zz4=;container=0;" vertex="1" parent="1">
+          <mxGeometry x="2965.5" y="655" width="65" height="65" as="geometry" />
+        </mxCell>
+        <mxCell id="C39UIkgcu5n6xboTU2DO-135" value="" style="shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;imageAspect=0;editableCssRules=.*;image=data:image/svg+xml,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjEgMSAyMiAyMiIgaGVpZ2h0PSI3MzMuMzMzMzMzMzMzMzMzNCIgd2lkdGg9IjczMy4zMzMzMzMzMzMzMzM0Ij48cGF0aCBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZT0iI0I4NTQ1MCIgZmlsbD0iI0Y4Q0VDQyIgZD0iTTEyIDIyYy00LjcxNCAwLTcuMDcxIDAtOC41MzYtMS40NjVDMiAxOS4wNzIgMiAxNi43MTQgMiAxMnMwLTcuMDcxIDEuNDY0LTguNTM2QzQuOTMgMiA3LjI4NiAyIDEyIDJzNy4wNzEgMCA4LjUzNSAxLjQ2NEMyMiA0LjkzIDIyIDcuMjg2IDIyIDEyczAgNy4wNzEtMS40NjUgOC41MzVDMTkuMDcyIDIyIDE2LjcxNCAyMiAxMiAyMloiIG9wYWNpdHk9Ii41Ii8+LyZndDs8cGF0aCBmaWxsPSIjQjg1NDUwIiBkPSJNOC45NyA4Ljk3YS43NS43NSAwIDAgMSAxLjA2IDBMMTIgMTAuOTRsMS45Ny0xLjk3YS43NS43NSAwIDEgMSAxLjA2IDEuMDZMMTMuMDYgMTJsMS45NyAxLjk3YS43NS43NSAwIDEgMS0xLjA2IDEuMDZMMTIgMTMuMDZsLTEuOTcgMS45N2EuNzUuNzUgMCAwIDEtMS4wNi0xLjA2TDEwLjk0IDEybC0xLjk3LTEuOTdhLjc1Ljc1IDAgMCAxIDAtMS4wNiIvPjwvc3ZnPg==;container=0;" vertex="1" parent="1">
+          <mxGeometry x="3168" y="655" width="65" height="65" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/docs/img/dge_shacl.es.drawio
+++ b/docs/img/dge_shacl.es.drawio
@@ -1,0 +1,219 @@
+<mxfile host="Electron" agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/26.2.2 Chrome/134.0.6998.178 Electron/35.1.2 Safari/537.36" version="26.2.2">
+  <diagram name="Page-1" id="HUJMsCtopg-WY_ma1BH4">
+    <mxGraphModel dx="5863" dy="3386" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="R9IATIc22B4kfkr1Bm4C-1" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#C9E2DF;strokeColor=#82b366;strokeWidth=5;dashed=1;dashPattern=1 2;fillOpacity=20;" vertex="1" parent="1">
+          <mxGeometry x="3276" y="620" width="304" height="164" as="geometry" />
+        </mxCell>
+        <mxCell id="R9IATIc22B4kfkr1Bm4C-6" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFCCCC;strokeColor=#FF6666;strokeWidth=5;dashed=1;dashPattern=1 2;fillOpacity=20;" vertex="1" parent="1">
+          <mxGeometry x="3276" y="790" width="304" height="160" as="geometry" />
+        </mxCell>
+        <mxCell id="R9IATIc22B4kfkr1Bm4C-11" value="" style="shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;imageAspect=0;editableCssRules=.*;image=data:image/svg+xml,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjEgMSAyMiAyMiIgaGVpZ2h0PSI3MzMuMzMzMzMzMzMzMzMzNCIgd2lkdGg9IjczMy4zMzMzMzMzMzMzMzM0Ij48cGF0aCBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZT0iI2RmNmMwYyIgZmlsbD0iI2ZiZjJlOSIgZD0iTTEyIDJDNy4yODYgMiA0LjkyOSAyIDMuNDY0IDMuNDY0IDIgNC45MyAyIDcuMjg2IDIgMTJzMCA3LjA3MSAxLjQ2NCA4LjUzNUM0LjkzIDIyIDcuMjg2IDIyIDEyIDIyczcuMDcxIDAgOC41MzUtMS40NjVDMjIgMTkuMDcyIDIyIDE2LjcxNCAyMiAxMnMwLTcuMDcxLTEuNDY1LTguNTM2QzE5LjA3MiAyIDE2LjcxNCAyIDEyIDJaIiBvcGFjaXR5PSIuNSIvPjxwYXRoIGZpbGw9IiNkZjZjMGMiIGQ9Ik0xMiA2LjI1YS43NS43NSAwIDAgMSAuNzUuNzV2NmEuNzUuNzUgMCAwIDEtMS41IDBWN2EuNzUuNzUgMCAwIDEgLjc1LS43NU0xMiAxN2ExIDEgMCAxIDAgMC0yIDEgMSAwIDAgMCAwIDIiLz48L3N2Zz4=;" vertex="1" parent="1">
+          <mxGeometry x="3295.5" y="793" width="65" height="65" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-11" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="680" y="500" width="740" height="570" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-12" value="" style="group" parent="eQ03b7rNsuCkoR8bZF5h-11" vertex="1" connectable="0">
+          <mxGeometry width="740" height="570" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-5" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#C9E2DF;fontSize=25;verticalAlign=top;fontStyle=1;fontFamily=Poppins;strokeColor=#00A99D;strokeWidth=3;fillOpacity=75;fontColor=#10739E;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;" parent="eQ03b7rNsuCkoR8bZF5h-12" vertex="1">
+          <mxGeometry y="37" width="740" height="533" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-7" value="&lt;b style=&quot;font-size: 40px;&quot;&gt;&lt;font style=&quot;font-size: 40px;&quot;&gt;Grafo de datos&lt;/font&gt;&lt;/b&gt;&lt;b style=&quot;font-size: 40px;&quot;&gt;&lt;font data-font-src=&quot;https://fonts.googleapis.com/css?family=Source+Sans+Pro&quot; style=&quot;font-size: 40px;&quot;&gt;&lt;br style=&quot;font-size: 40px;&quot;&gt;&lt;/font&gt;&lt;/b&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=1;fontColor=#EEEEEE;strokeWidth=2;fontSize=40;fontFamily=Poppins;strokeColor=none;fillOpacity=100;fillColor=#154481;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;" parent="eQ03b7rNsuCkoR8bZF5h-12" vertex="1">
+          <mxGeometry x="170.74999999999977" y="-10" width="398.5" height="100" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-9" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-12" vertex="1">
+          <mxGeometry x="140" y="170" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-13" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-12" vertex="1">
+          <mxGeometry x="310" y="360" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-14" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-12" vertex="1">
+          <mxGeometry x="410" y="160" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-15" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-12" vertex="1">
+          <mxGeometry x="250" y="229" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-16" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-12" vertex="1">
+          <mxGeometry x="80" y="360" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-17" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-12" vertex="1">
+          <mxGeometry x="540" y="420" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-18" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-12" vertex="1">
+          <mxGeometry x="470" y="278.5" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-19" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-12" vertex="1">
+          <mxGeometry x="630" y="160" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-20" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-12" vertex="1">
+          <mxGeometry x="250" y="120" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-21" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-12" vertex="1">
+          <mxGeometry x="191" y="470" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-22" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-12" vertex="1">
+          <mxGeometry x="191" y="340" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-23" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-12" vertex="1">
+          <mxGeometry x="397" y="450" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-24" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-12" vertex="1">
+          <mxGeometry x="600" y="300" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-42" style="rounded=1;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeColor=#154481;strokeWidth=15;endArrow=block;endFill=1;flowAnimation=1;startFill=0;shadow=0;jumpStyle=none;dashed=1;dashPattern=1 1;edgeStyle=orthogonalEdgeStyle;curved=1;endSize=7;startSize=7;opacity=90;" parent="1" source="eQ03b7rNsuCkoR8bZF5h-5" target="eQ03b7rNsuCkoR8bZF5h-27" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-54" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="2680" y="670" width="320" height="240" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-110" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;shadow=0;dashed=1;dashPattern=1 1;opacity=90;strokeColor=#154481;strokeWidth=15;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=11;fontColor=default;labelBackgroundColor=default;jumpStyle=none;startFill=0;startSize=7;endArrow=block;endFill=1;endSize=7;flowAnimation=1;curved=1;" parent="eQ03b7rNsuCkoR8bZF5h-54" source="eQ03b7rNsuCkoR8bZF5h-49" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="540" y="120" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-49" value="" style="rounded=1;whiteSpace=wrap;html=1;gradientColor=none;strokeColor=#154481;strokeWidth=5;fillColor=#00A99D;fillOpacity=20;dashed=1;container=0;" parent="eQ03b7rNsuCkoR8bZF5h-54" vertex="1">
+          <mxGeometry width="320" height="240" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-50" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;container=0;" parent="eQ03b7rNsuCkoR8bZF5h-54" vertex="1">
+          <mxGeometry x="160" y="50" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-51" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;container=0;" parent="eQ03b7rNsuCkoR8bZF5h-54" vertex="1">
+          <mxGeometry x="247" y="140" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-52" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;container=0;" parent="eQ03b7rNsuCkoR8bZF5h-54" vertex="1">
+          <mxGeometry x="41" y="160" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-53" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;container=0;" parent="eQ03b7rNsuCkoR8bZF5h-54" vertex="1">
+          <mxGeometry x="41" y="30" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-55" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="1680" y="490" width="740" height="580" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-27" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#C9E2DF;fontSize=25;verticalAlign=top;fontStyle=1;fontFamily=Poppins;strokeColor=#00A99D;strokeWidth=3;fillOpacity=75;fontColor=#10739E;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;" parent="eQ03b7rNsuCkoR8bZF5h-55" vertex="1">
+          <mxGeometry y="47" width="740" height="533" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-28" value="&lt;b style=&quot;font-size: 40px;&quot;&gt;&lt;font data-font-src=&quot;https://fonts.googleapis.com/css?family=Source+Sans+Pro&quot; style=&quot;font-size: 40px;&quot;&gt;Nodos de validación&lt;/font&gt;&lt;/b&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=1;fontColor=#EEEEEE;strokeWidth=2;fontSize=40;fontFamily=Poppins;strokeColor=none;fillOpacity=100;fillColor=#154481;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;" parent="eQ03b7rNsuCkoR8bZF5h-55" vertex="1">
+          <mxGeometry x="170.75" width="398.5" height="100" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-29" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-55" vertex="1">
+          <mxGeometry x="140" y="180" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-31" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-55" vertex="1">
+          <mxGeometry x="410" y="170" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-32" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-55" vertex="1">
+          <mxGeometry x="250" y="239" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-33" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-55" vertex="1">
+          <mxGeometry x="80" y="370" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-34" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-55" vertex="1">
+          <mxGeometry x="540" y="430" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-35" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-55" vertex="1">
+          <mxGeometry x="470" y="288.5" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-36" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-55" vertex="1">
+          <mxGeometry x="630" y="170" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-37" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-55" vertex="1">
+          <mxGeometry x="250" y="130" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-41" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-55" vertex="1">
+          <mxGeometry x="600" y="310" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-47" value="" style="group;glass=0;" parent="eQ03b7rNsuCkoR8bZF5h-55" vertex="1" connectable="0">
+          <mxGeometry x="150" y="320" width="320" height="240" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-45" value="" style="rounded=1;whiteSpace=wrap;html=1;gradientColor=none;strokeColor=#154481;strokeWidth=5;fillColor=#00A99D;fillOpacity=20;dashed=1;" parent="eQ03b7rNsuCkoR8bZF5h-47" vertex="1">
+          <mxGeometry width="320" height="240" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-30" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-47" vertex="1">
+          <mxGeometry x="160" y="50" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-40" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-47" vertex="1">
+          <mxGeometry x="247" y="140" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-38" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-47" vertex="1">
+          <mxGeometry x="41" y="160" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-39" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;" parent="eQ03b7rNsuCkoR8bZF5h-47" vertex="1">
+          <mxGeometry x="41" y="30" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-56" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.005;entryY=0.552;entryDx=0;entryDy=0;entryPerimeter=0;shadow=0;dashed=1;dashPattern=1 1;opacity=90;strokeColor=#154481;strokeWidth=15;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=11;fontColor=default;labelBackgroundColor=default;jumpStyle=none;startFill=0;startSize=7;endArrow=block;endFill=1;endSize=7;flowAnimation=1;curved=1;" parent="1" source="eQ03b7rNsuCkoR8bZF5h-27" target="eQ03b7rNsuCkoR8bZF5h-49" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-59" value="&lt;b style=&quot;font-size: 40px;&quot;&gt;&lt;font data-font-src=&quot;https://fonts.googleapis.com/css?family=Source+Sans+Pro&quot; style=&quot;font-size: 40px;&quot;&gt;Restricciones SHACL&lt;/font&gt;&lt;/b&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=1;fontColor=#EEEEEE;strokeWidth=2;fontSize=40;fontFamily=Poppins;strokeColor=none;fillOpacity=100;fillColor=#154481;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;" parent="1" vertex="1">
+          <mxGeometry x="2920" y="490" width="398.5" height="100" as="geometry" />
+        </mxCell>
+        <mxCell id="R9IATIc22B4kfkr1Bm4C-3" style="rounded=1;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;shadow=0;dashed=1;dashPattern=1 1;opacity=90;strokeColor=#154481;strokeWidth=15;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=11;fontColor=default;labelBackgroundColor=default;jumpStyle=none;startFill=0;startSize=7;endArrow=block;endFill=1;endSize=7;flowAnimation=1;edgeStyle=orthogonalEdgeStyle;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" edge="1" parent="1" source="R9IATIc22B4kfkr1Bm4C-1" target="R9IATIc22B4kfkr1Bm4C-4">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="3580" y="700" />
+              <mxPoint x="3610" y="700" />
+              <mxPoint x="3610" y="645" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="R9IATIc22B4kfkr1Bm4C-4" value="&lt;b&gt;Conformidad con DCAT-AP-ES&lt;/b&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=1;strokeWidth=6;fontSize=28;fontFamily=Poppins;strokeColor=#82B366;fillOpacity=100;fillColor=#d5e8d4;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontColor=#82B366;" vertex="1" parent="1">
+          <mxGeometry x="3720" y="550" width="280" height="190" as="geometry" />
+        </mxCell>
+        <mxCell id="R9IATIc22B4kfkr1Bm4C-2" value="&lt;b&gt;&lt;font style=&quot;color: rgb(184, 84, 80);&quot;&gt;Errores &lt;/font&gt;&lt;font style=&quot;color: rgb(184, 84, 80);&quot;&gt;y&lt;/font&gt; &lt;font style=&quot;color: rgb(223, 108, 12);&quot;&gt;recomendaciones de mejora&lt;/font&gt;&lt;/b&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=1;strokeWidth=6;fontSize=28;fontFamily=Poppins;strokeColor=#b85450;fillOpacity=100;fillColor=#f8cecc;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;" vertex="1" parent="1">
+          <mxGeometry x="3720" y="820" width="280" height="190" as="geometry" />
+        </mxCell>
+        <mxCell id="R9IATIc22B4kfkr1Bm4C-7" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;shadow=0;dashed=1;dashPattern=1 1;opacity=90;strokeColor=#154481;strokeWidth=15;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=11;fontColor=default;labelBackgroundColor=default;jumpStyle=none;startFill=0;startSize=7;endArrow=block;endFill=1;endSize=7;flowAnimation=1;curved=1;" edge="1" parent="1" source="R9IATIc22B4kfkr1Bm4C-6" target="R9IATIc22B4kfkr1Bm4C-2">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="R9IATIc22B4kfkr1Bm4C-9" value="" style="shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;imageAspect=0;editableCssRules=.*;image=data:image/svg+xml,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjEgMSAyMiAyMiIgaGVpZ2h0PSI3MzMuMzMzMzMzMzMzMzMzNCIgd2lkdGg9IjczMy4zMzMzMzMzMzMzMzM0Ij48cGF0aCBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZT0iI2RmNmMwYyIgZmlsbD0iI2ZiZjJlOSIgZD0iTTEyIDJDNy4yODYgMiA0LjkyOSAyIDMuNDY0IDMuNDY0IDIgNC45MyAyIDcuMjg2IDIgMTJzMCA3LjA3MSAxLjQ2NCA4LjUzNUM0LjkzIDIyIDcuMjg2IDIyIDEyIDIyczcuMDcxIDAgOC41MzUtMS40NjVDMjIgMTkuMDcyIDIyIDE2LjcxNCAyMiAxMnMwLTcuMDcxLTEuNDY1LTguNTM2QzE5LjA3MiAyIDE2LjcxNCAyIDEyIDJaIiBvcGFjaXR5PSIuNSIvPjxwYXRoIGZpbGw9IiNkZjZjMGMiIGQ9Ik0xMiA2LjI1YS43NS43NSAwIDAgMSAuNzUuNzV2NmEuNzUuNzUgMCAwIDEtMS41IDBWN2EuNzUuNzUgMCAwIDEgLjc1LS43NU0xMiAxN2ExIDEgMCAxIDAgMC0yIDEgMSAwIDAgMCAwIDIiLz48L3N2Zz4=;" vertex="1" parent="1">
+          <mxGeometry x="3395.5" y="875" width="65" height="65" as="geometry" />
+        </mxCell>
+        <mxCell id="R9IATIc22B4kfkr1Bm4C-5" value="" style="shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;imageAspect=0;editableCssRules=.*;image=data:image/svg+xml,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjEgMSAyMiAyMiIgaGVpZ2h0PSI3MzMuMzMzMzMzMzMzMzMzNCIgd2lkdGg9IjczMy4zMzMzMzMzMzMzMzM0Ij4mI3hhOyAgJiN4YTsgIDxwYXRoIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlPSIjODJCMzY2IiBmaWxsPSIjRDVFOEQ0IiBkPSJNMTIgMjJDNy4yODU5NSAyMiA0LjkyODkzIDIyIDMuNDY0NDcgMjAuNTM1NUMyIDE5LjA3MTEgMiAxNi43MTQgMiAxMkMyIDcuMjg1OTUgMiA0LjkyODkzIDMuNDY0NDcgMy40NjQ0N0M0LjkyODkzIDIgNy4yODU5NSAyIDEyIDJDMTYuNzE0IDIgMTkuMDcxMSAyIDIwLjUzNTUgMy40NjQ0N0MyMiA0LjkyODkzIDIyIDcuMjg1OTUgMjIgMTJDMjIgMTYuNzE0IDIyIDE5LjA3MTEgMjAuNTM1NSAyMC41MzU1QzE5LjA3MTEgMjIgMTYuNzE0IDIyIDEyIDIyWiIgb3BhY2l0eT0iMC41Ii8+JiN4YTsgICYjeGE7ICAmI3hhOyAgPHBhdGggZmlsbD0iIzgyQjM2NiIgZD0iTTE2LjAzMDMgOC45Njk2N0MxNi4zMjMyIDkuMjYyNTYgMTYuMzIzMiA5LjczNzQ0IDE2LjAzMDMgMTAuMDMwM0wxMS4wMzAzIDE1LjAzMDNDMTAuNzM3NCAxNS4zMjMyIDEwLjI2MjYgMTUuMzIzMiA5Ljk2OTY3IDE1LjAzMDNMNy45Njk2NyAxMy4wMzAzQzcuNjc2NzggMTIuNzM3NCA3LjY3Njc4IDEyLjI2MjYgNy45Njk2NyAxMS45Njk3QzguMjYyNTYgMTEuNjc2OCA4LjczNzQ0IDExLjY3NjggOS4wMzAzMyAxMS45Njk3TDEwLjUgMTMuNDM5M0wxNC45Njk3IDguOTY5NjdDMTUuMjYyNiA4LjY3Njc4IDE1LjczNzQgOC42NzY3OCAxNi4wMzAzIDguOTY5NjdaIi8+JiN4YTs8L3N2Zz4=;container=0;" vertex="1" parent="1">
+          <mxGeometry x="3395.5" y="630" width="65" height="65" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-61" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;container=0;" parent="1" vertex="1">
+          <mxGeometry x="3215.5" y="637.5" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-76" value="" style="shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;imageAspect=0;editableCssRules=.*;image=data:image/svg+xml,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjEgMSAyMiAyMiIgaGVpZ2h0PSI3MzMuMzMzMzMzMzMzMzMzNCIgd2lkdGg9IjczMy4zMzMzMzMzMzMzMzM0Ij4mI3hhOyAgJiN4YTsgIDxwYXRoIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlPSIjODJCMzY2IiBmaWxsPSIjRDVFOEQ0IiBkPSJNMTIgMjJDNy4yODU5NSAyMiA0LjkyODkzIDIyIDMuNDY0NDcgMjAuNTM1NUMyIDE5LjA3MTEgMiAxNi43MTQgMiAxMkMyIDcuMjg1OTUgMiA0LjkyODkzIDMuNDY0NDcgMy40NjQ0N0M0LjkyODkzIDIgNy4yODU5NSAyIDEyIDJDMTYuNzE0IDIgMTkuMDcxMSAyIDIwLjUzNTUgMy40NjQ0N0MyMiA0LjkyODkzIDIyIDcuMjg1OTUgMjIgMTJDMjIgMTYuNzE0IDIyIDE5LjA3MTEgMjAuNTM1NSAyMC41MzU1QzE5LjA3MTEgMjIgMTYuNzE0IDIyIDEyIDIyWiIgb3BhY2l0eT0iMC41Ii8+JiN4YTsgICYjeGE7ICAmI3hhOyAgPHBhdGggZmlsbD0iIzgyQjM2NiIgZD0iTTE2LjAzMDMgOC45Njk2N0MxNi4zMjMyIDkuMjYyNTYgMTYuMzIzMiA5LjczNzQ0IDE2LjAzMDMgMTAuMDMwM0wxMS4wMzAzIDE1LjAzMDNDMTAuNzM3NCAxNS4zMjMyIDEwLjI2MjYgMTUuMzIzMiA5Ljk2OTY3IDE1LjAzMDNMNy45Njk2NyAxMy4wMzAzQzcuNjc2NzggMTIuNzM3NCA3LjY3Njc4IDEyLjI2MjYgNy45Njk2NyAxMS45Njk3QzguMjYyNTYgMTEuNjc2OCA4LjczNzQ0IDExLjY3NjggOS4wMzAzMyAxMS45Njk3TDEwLjUgMTMuNDM5M0wxNC45Njk3IDguOTY5NjdDMTUuMjYyNiA4LjY3Njc4IDE1LjczNzQgOC42NzY3OCAxNi4wMzAzIDguOTY5NjdaIi8+JiN4YTs8L3N2Zz4=;container=0;" parent="1" vertex="1">
+          <mxGeometry x="3295.5" y="630" width="65" height="65" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-78" value="" style="shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;imageAspect=0;editableCssRules=.*;image=data:image/svg+xml,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjEgMSAyMiAyMiIgaGVpZ2h0PSI3MzMuMzMzMzMzMzMzMzMzNCIgd2lkdGg9IjczMy4zMzMzMzMzMzMzMzM0Ij4mI3hhOyAgJiN4YTsgIDxwYXRoIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlPSIjODJCMzY2IiBmaWxsPSIjRDVFOEQ0IiBkPSJNMTIgMjJDNy4yODU5NSAyMiA0LjkyODkzIDIyIDMuNDY0NDcgMjAuNTM1NUMyIDE5LjA3MTEgMiAxNi43MTQgMiAxMkMyIDcuMjg1OTUgMiA0LjkyODkzIDMuNDY0NDcgMy40NjQ0N0M0LjkyODkzIDIgNy4yODU5NSAyIDEyIDJDMTYuNzE0IDIgMTkuMDcxMSAyIDIwLjUzNTUgMy40NjQ0N0MyMiA0LjkyODkzIDIyIDcuMjg1OTUgMjIgMTJDMjIgMTYuNzE0IDIyIDE5LjA3MTEgMjAuNTM1NSAyMC41MzU1QzE5LjA3MTEgMjIgMTYuNzE0IDIyIDEyIDIyWiIgb3BhY2l0eT0iMC41Ii8+JiN4YTsgICYjeGE7ICAmI3hhOyAgPHBhdGggZmlsbD0iIzgyQjM2NiIgZD0iTTE2LjAzMDMgOC45Njk2N0MxNi4zMjMyIDkuMjYyNTYgMTYuMzIzMiA5LjczNzQ0IDE2LjAzMDMgMTAuMDMwM0wxMS4wMzAzIDE1LjAzMDNDMTAuNzM3NCAxNS4zMjMyIDEwLjI2MjYgMTUuMzIzMiA5Ljk2OTY3IDE1LjAzMDNMNy45Njk2NyAxMy4wMzAzQzcuNjc2NzggMTIuNzM3NCA3LjY3Njc4IDEyLjI2MjYgNy45Njk2NyAxMS45Njk3QzguMjYyNTYgMTEuNjc2OCA4LjczNzQ0IDExLjY3NjggOS4wMzAzMyAxMS45Njk3TDEwLjUgMTMuNDM5M0wxNC45Njk3IDguOTY5NjdDMTUuMjYyNiA4LjY3Njc4IDE1LjczNzQgOC42NzY3OCAxNi4wMzAzIDguOTY5NjdaIi8+JiN4YTs8L3N2Zz4=;container=0;" parent="1" vertex="1">
+          <mxGeometry x="3498" y="630" width="65" height="65" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-111" value="" style="shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;imageAspect=0;editableCssRules=.*;image=data:image/svg+xml,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjEgMSAyMiAyMiIgaGVpZ2h0PSI3MzMuMzMzMzMzMzMzMzMzNCIgd2lkdGg9IjczMy4zMzMzMzMzMzMzMzM0Ij4mI3hhOyAgJiN4YTsgIDxwYXRoIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlPSIjODJCMzY2IiBmaWxsPSIjRDVFOEQ0IiBkPSJNMTIgMjJDNy4yODU5NSAyMiA0LjkyODkzIDIyIDMuNDY0NDcgMjAuNTM1NUMyIDE5LjA3MTEgMiAxNi43MTQgMiAxMkMyIDcuMjg1OTUgMiA0LjkyODkzIDMuNDY0NDcgMy40NjQ0N0M0LjkyODkzIDIgNy4yODU5NSAyIDEyIDJDMTYuNzE0IDIgMTkuMDcxMSAyIDIwLjUzNTUgMy40NjQ0N0MyMiA0LjkyODkzIDIyIDcuMjg1OTUgMjIgMTJDMjIgMTYuNzE0IDIyIDE5LjA3MTEgMjAuNTM1NSAyMC41MzU1QzE5LjA3MTEgMjIgMTYuNzE0IDIyIDEyIDIyWiIgb3BhY2l0eT0iMC41Ii8+JiN4YTsgICYjeGE7ICAmI3hhOyAgPHBhdGggZmlsbD0iIzgyQjM2NiIgZD0iTTE2LjAzMDMgOC45Njk2N0MxNi4zMjMyIDkuMjYyNTYgMTYuMzIzMiA5LjczNzQ0IDE2LjAzMDMgMTAuMDMwM0wxMS4wMzAzIDE1LjAzMDNDMTAuNzM3NCAxNS4zMjMyIDEwLjI2MjYgMTUuMzIzMiA5Ljk2OTY3IDE1LjAzMDNMNy45Njk2NyAxMy4wMzAzQzcuNjc2NzggMTIuNzM3NCA3LjY3Njc4IDEyLjI2MjYgNy45Njk2NyAxMS45Njk3QzguMjYyNTYgMTEuNjc2OCA4LjczNzQ0IDExLjY3NjggOS4wMzAzMyAxMS45Njk3TDEwLjUgMTMuNDM5M0wxNC45Njk3IDguOTY5NjdDMTUuMjYyNiA4LjY3Njc4IDE1LjczNzQgOC42NzY3OCAxNi4wMzAzIDguOTY5NjdaIi8+JiN4YTs8L3N2Zz4=;container=0;" parent="1" vertex="1">
+          <mxGeometry x="3395.5" y="712" width="65" height="65" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-86" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;container=0;" parent="1" vertex="1">
+          <mxGeometry x="3215.5" y="719.5" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-88" value="" style="shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;imageAspect=0;editableCssRules=.*;image=data:image/svg+xml,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjEgMSAyMiAyMiIgaGVpZ2h0PSI3MzMuMzMzMzMzMzMzMzMzNCIgd2lkdGg9IjczMy4zMzMzMzMzMzMzMzM0Ij4mI3hhOyAgJiN4YTsgIDxwYXRoIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlPSIjODJCMzY2IiBmaWxsPSIjRDVFOEQ0IiBkPSJNMTIgMjJDNy4yODU5NSAyMiA0LjkyODkzIDIyIDMuNDY0NDcgMjAuNTM1NUMyIDE5LjA3MTEgMiAxNi43MTQgMiAxMkMyIDcuMjg1OTUgMiA0LjkyODkzIDMuNDY0NDcgMy40NjQ0N0M0LjkyODkzIDIgNy4yODU5NSAyIDEyIDJDMTYuNzE0IDIgMTkuMDcxMSAyIDIwLjUzNTUgMy40NjQ0N0MyMiA0LjkyODkzIDIyIDcuMjg1OTUgMjIgMTJDMjIgMTYuNzE0IDIyIDE5LjA3MTEgMjAuNTM1NSAyMC41MzU1QzE5LjA3MTEgMjIgMTYuNzE0IDIyIDEyIDIyWiIgb3BhY2l0eT0iMC41Ii8+JiN4YTsgICYjeGE7ICAmI3hhOyAgPHBhdGggZmlsbD0iIzgyQjM2NiIgZD0iTTE2LjAzMDMgOC45Njk2N0MxNi4zMjMyIDkuMjYyNTYgMTYuMzIzMiA5LjczNzQ0IDE2LjAzMDMgMTAuMDMwM0wxMS4wMzAzIDE1LjAzMDNDMTAuNzM3NCAxNS4zMjMyIDEwLjI2MjYgMTUuMzIzMiA5Ljk2OTY3IDE1LjAzMDNMNy45Njk2NyAxMy4wMzAzQzcuNjc2NzggMTIuNzM3NCA3LjY3Njc4IDEyLjI2MjYgNy45Njk2NyAxMS45Njk3QzguMjYyNTYgMTEuNjc2OCA4LjczNzQ0IDExLjY3NjggOS4wMzAzMyAxMS45Njk3TDEwLjUgMTMuNDM5M0wxNC45Njk3IDguOTY5NjdDMTUuMjYyNiA4LjY3Njc4IDE1LjczNzQgOC42NzY3OCAxNi4wMzAzIDguOTY5NjdaIi8+JiN4YTs8L3N2Zz4=;container=0;" parent="1" vertex="1">
+          <mxGeometry x="3295.5" y="712" width="65" height="65" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-90" value="" style="shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;imageAspect=0;editableCssRules=.*;image=data:image/svg+xml,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjEgMSAyMiAyMiIgaGVpZ2h0PSI3MzMuMzMzMzMzMzMzMzMzNCIgd2lkdGg9IjczMy4zMzMzMzMzMzMzMzM0Ij4mI3hhOyAgJiN4YTsgIDxwYXRoIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlPSIjODJCMzY2IiBmaWxsPSIjRDVFOEQ0IiBkPSJNMTIgMjJDNy4yODU5NSAyMiA0LjkyODkzIDIyIDMuNDY0NDcgMjAuNTM1NUMyIDE5LjA3MTEgMiAxNi43MTQgMiAxMkMyIDcuMjg1OTUgMiA0LjkyODkzIDMuNDY0NDcgMy40NjQ0N0M0LjkyODkzIDIgNy4yODU5NSAyIDEyIDJDMTYuNzE0IDIgMTkuMDcxMSAyIDIwLjUzNTUgMy40NjQ0N0MyMiA0LjkyODkzIDIyIDcuMjg1OTUgMjIgMTJDMjIgMTYuNzE0IDIyIDE5LjA3MTEgMjAuNTM1NSAyMC41MzU1QzE5LjA3MTEgMjIgMTYuNzE0IDIyIDEyIDIyWiIgb3BhY2l0eT0iMC41Ii8+JiN4YTsgICYjeGE7ICAmI3hhOyAgPHBhdGggZmlsbD0iIzgyQjM2NiIgZD0iTTE2LjAzMDMgOC45Njk2N0MxNi4zMjMyIDkuMjYyNTYgMTYuMzIzMiA5LjczNzQ0IDE2LjAzMDMgMTAuMDMwM0wxMS4wMzAzIDE1LjAzMDNDMTAuNzM3NCAxNS4zMjMyIDEwLjI2MjYgMTUuMzIzMiA5Ljk2OTY3IDE1LjAzMDNMNy45Njk2NyAxMy4wMzAzQzcuNjc2NzggMTIuNzM3NCA3LjY3Njc4IDEyLjI2MjYgNy45Njk2NyAxMS45Njk3QzguMjYyNTYgMTEuNjc2OCA4LjczNzQ0IDExLjY3NjggOS4wMzAzMyAxMS45Njk3TDEwLjUgMTMuNDM5M0wxNC45Njk3IDguOTY5NjdDMTUuMjYyNiA4LjY3Njc4IDE1LjczNzQgOC42NzY3OCAxNi4wMzAzIDguOTY5NjdaIi8+JiN4YTs8L3N2Zz4=;container=0;" parent="1" vertex="1">
+          <mxGeometry x="3498" y="712" width="65" height="65" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-98" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;container=0;" parent="1" vertex="1">
+          <mxGeometry x="3215.5" y="800.5" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-101" value="" style="shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;imageAspect=0;editableCssRules=.*;image=data:image/svg+xml,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjEgMSAyMiAyMiIgaGVpZ2h0PSI3MzMuMzMzMzMzMzMzMzMzNCIgd2lkdGg9IjczMy4zMzMzMzMzMzMzMzM0Ij48cGF0aCBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZT0iI0I4NTQ1MCIgZmlsbD0iI0Y4Q0VDQyIgZD0iTTEyIDIyYy00LjcxNCAwLTcuMDcxIDAtOC41MzYtMS40NjVDMiAxOS4wNzIgMiAxNi43MTQgMiAxMnMwLTcuMDcxIDEuNDY0LTguNTM2QzQuOTMgMiA3LjI4NiAyIDEyIDJzNy4wNzEgMCA4LjUzNSAxLjQ2NEMyMiA0LjkzIDIyIDcuMjg2IDIyIDEyczAgNy4wNzEtMS40NjUgOC41MzVDMTkuMDcyIDIyIDE2LjcxNCAyMiAxMiAyMloiIG9wYWNpdHk9Ii41Ii8+LyZndDs8cGF0aCBmaWxsPSIjQjg1NDUwIiBkPSJNOC45NyA4Ljk3YS43NS43NSAwIDAgMSAxLjA2IDBMMTIgMTAuOTRsMS45Ny0xLjk3YS43NS43NSAwIDEgMSAxLjA2IDEuMDZMMTMuMDYgMTJsMS45NyAxLjk3YS43NS43NSAwIDEgMS0xLjA2IDEuMDZMMTIgMTMuMDZsLTEuOTcgMS45N2EuNzUuNzUgMCAwIDEtMS4wNi0xLjA2TDEwLjk0IDEybC0xLjk3LTEuOTdhLjc1Ljc1IDAgMCAxIDAtMS4wNiIvPjwvc3ZnPg==;container=0;" parent="1" vertex="1">
+          <mxGeometry x="3395.5" y="793" width="65" height="65" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-102" value="" style="shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;imageAspect=0;editableCssRules=.*;image=data:image/svg+xml,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjEgMSAyMiAyMiIgaGVpZ2h0PSI3MzMuMzMzMzMzMzMzMzMzNCIgd2lkdGg9IjczMy4zMzMzMzMzMzMzMzM0Ij4mI3hhOyAgJiN4YTsgIDxwYXRoIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlPSIjODJCMzY2IiBmaWxsPSIjRDVFOEQ0IiBkPSJNMTIgMjJDNy4yODU5NSAyMiA0LjkyODkzIDIyIDMuNDY0NDcgMjAuNTM1NUMyIDE5LjA3MTEgMiAxNi43MTQgMiAxMkMyIDcuMjg1OTUgMiA0LjkyODkzIDMuNDY0NDcgMy40NjQ0N0M0LjkyODkzIDIgNy4yODU5NSAyIDEyIDJDMTYuNzE0IDIgMTkuMDcxMSAyIDIwLjUzNTUgMy40NjQ0N0MyMiA0LjkyODkzIDIyIDcuMjg1OTUgMjIgMTJDMjIgMTYuNzE0IDIyIDE5LjA3MTEgMjAuNTM1NSAyMC41MzU1QzE5LjA3MTEgMjIgMTYuNzE0IDIyIDEyIDIyWiIgb3BhY2l0eT0iMC41Ii8+JiN4YTsgICYjeGE7ICAmI3hhOyAgPHBhdGggZmlsbD0iIzgyQjM2NiIgZD0iTTE2LjAzMDMgOC45Njk2N0MxNi4zMjMyIDkuMjYyNTYgMTYuMzIzMiA5LjczNzQ0IDE2LjAzMDMgMTAuMDMwM0wxMS4wMzAzIDE1LjAzMDNDMTAuNzM3NCAxNS4zMjMyIDEwLjI2MjYgMTUuMzIzMiA5Ljk2OTY3IDE1LjAzMDNMNy45Njk2NyAxMy4wMzAzQzcuNjc2NzggMTIuNzM3NCA3LjY3Njc4IDEyLjI2MjYgNy45Njk2NyAxMS45Njk3QzguMjYyNTYgMTEuNjc2OCA4LjczNzQ0IDExLjY3NjggOS4wMzAzMyAxMS45Njk3TDEwLjUgMTMuNDM5M0wxNC45Njk3IDguOTY5NjdDMTUuMjYyNiA4LjY3Njc4IDE1LjczNzQgOC42NzY3OCAxNi4wMzAzIDguOTY5NjdaIi8+JiN4YTs8L3N2Zz4=;container=0;" parent="1" vertex="1">
+          <mxGeometry x="3498" y="793" width="65" height="65" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-104" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#00A99D;strokeColor=none;container=0;" parent="1" vertex="1">
+          <mxGeometry x="3215.5" y="882.5" width="51" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-106" value="" style="shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;imageAspect=0;editableCssRules=.*;image=data:image/svg+xml,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjEgMSAyMiAyMiIgaGVpZ2h0PSI3MzMuMzMzMzMzMzMzMzMzNCIgd2lkdGg9IjczMy4zMzMzMzMzMzMzMzM0Ij4mI3hhOyAgJiN4YTsgIDxwYXRoIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlPSIjODJCMzY2IiBmaWxsPSIjRDVFOEQ0IiBkPSJNMTIgMjJDNy4yODU5NSAyMiA0LjkyODkzIDIyIDMuNDY0NDcgMjAuNTM1NUMyIDE5LjA3MTEgMiAxNi43MTQgMiAxMkMyIDcuMjg1OTUgMiA0LjkyODkzIDMuNDY0NDcgMy40NjQ0N0M0LjkyODkzIDIgNy4yODU5NSAyIDEyIDJDMTYuNzE0IDIgMTkuMDcxMSAyIDIwLjUzNTUgMy40NjQ0N0MyMiA0LjkyODkzIDIyIDcuMjg1OTUgMjIgMTJDMjIgMTYuNzE0IDIyIDE5LjA3MTEgMjAuNTM1NSAyMC41MzU1QzE5LjA3MTEgMjIgMTYuNzE0IDIyIDEyIDIyWiIgb3BhY2l0eT0iMC41Ii8+JiN4YTsgICYjeGE7ICAmI3hhOyAgPHBhdGggZmlsbD0iIzgyQjM2NiIgZD0iTTE2LjAzMDMgOC45Njk2N0MxNi4zMjMyIDkuMjYyNTYgMTYuMzIzMiA5LjczNzQ0IDE2LjAzMDMgMTAuMDMwM0wxMS4wMzAzIDE1LjAzMDNDMTAuNzM3NCAxNS4zMjMyIDEwLjI2MjYgMTUuMzIzMiA5Ljk2OTY3IDE1LjAzMDNMNy45Njk2NyAxMy4wMzAzQzcuNjc2NzggMTIuNzM3NCA3LjY3Njc4IDEyLjI2MjYgNy45Njk2NyAxMS45Njk3QzguMjYyNTYgMTEuNjc2OCA4LjczNzQ0IDExLjY3NjggOS4wMzAzMyAxMS45Njk3TDEwLjUgMTMuNDM5M0wxNC45Njk3IDguOTY5NjdDMTUuMjYyNiA4LjY3Njc4IDE1LjczNzQgOC42NzY3OCAxNi4wMzAzIDguOTY5NjdaIi8+JiN4YTs8L3N2Zz4=;container=0;" parent="1" vertex="1">
+          <mxGeometry x="3295.5" y="875" width="65" height="65" as="geometry" />
+        </mxCell>
+        <mxCell id="eQ03b7rNsuCkoR8bZF5h-89" value="" style="shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;imageAspect=0;editableCssRules=.*;image=data:image/svg+xml,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjEgMSAyMiAyMiIgaGVpZ2h0PSI3MzMuMzMzMzMzMzMzMzMzNCIgd2lkdGg9IjczMy4zMzMzMzMzMzMzMzM0Ij48cGF0aCBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZT0iI0I4NTQ1MCIgZmlsbD0iI0Y4Q0VDQyIgZD0iTTEyIDIyYy00LjcxNCAwLTcuMDcxIDAtOC41MzYtMS40NjVDMiAxOS4wNzIgMiAxNi43MTQgMiAxMnMwLTcuMDcxIDEuNDY0LTguNTM2QzQuOTMgMiA3LjI4NiAyIDEyIDJzNy4wNzEgMCA4LjUzNSAxLjQ2NEMyMiA0LjkzIDIyIDcuMjg2IDIyIDEyczAgNy4wNzEtMS40NjUgOC41MzVDMTkuMDcyIDIyIDE2LjcxNCAyMiAxMiAyMloiIG9wYWNpdHk9Ii41Ii8+LyZndDs8cGF0aCBmaWxsPSIjQjg1NDUwIiBkPSJNOC45NyA4Ljk3YS43NS43NSAwIDAgMSAxLjA2IDBMMTIgMTAuOTRsMS45Ny0xLjk3YS43NS43NSAwIDEgMSAxLjA2IDEuMDZMMTMuMDYgMTJsMS45NyAxLjk3YS43NS43NSAwIDEgMS0xLjA2IDEuMDZMMTIgMTMuMDZsLTEuOTcgMS45N2EuNzUuNzUgMCAwIDEtMS4wNi0xLjA2TDEwLjk0IDEybC0xLjk3LTEuOTdhLjc1Ljc1IDAgMCAxIDAtMS4wNiIvPjwvc3ZnPg==;container=0;" parent="1" vertex="1">
+          <mxGeometry x="3498" y="875" width="65" height="65" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/docs/validation.en.md
+++ b/docs/validation.en.md
@@ -1,0 +1,103 @@
+![](img/dge_shacl.en.drawio "Ilustración . Description of SHACL validation steps"){ align=center width="100%"}
+
+To verify that the metadata exchange is technically compliant with [DCAT-AP-EN](/), the [SHACL shapes available in the repository](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0) graphs can be used. Shapes Constraint Language* (SHACL) is a [W3C recommendation](https://www.w3.org/TR/shacl/]) for expressing constraints in an RDF knowledge graph. 
+
+SHACL shapes allow checking whether a catalog expressed in an RDF serialization is valid. Since it should be possible to transform the data exchange to RDF for DCAT-AP-ES compliance, these SHACL forms can be used in any data exchange context. However, the provided SHACL forms are only a starting point for implementers.
+
+By using these templates, it is possible to identify and correct possible deviations from the specification, thereby improving the quality of the metadata produced. In addition, interactive tools such as the [SHACL playground](https://shacl-playground.zazuko.com/) [^1] or the [European Commission Interoperability Testbed](https://www.itb.ec.europa.eu/shacl/any/upload) [^2], which provides an online service where it is possible to upload and validate RDF files against DCAT-AP-ES SHACL forms, facilitate the validation of DCAT-AP files using SHACL.
+
+!!! info "Information" 
+
+    - More information about validation and SHACL forms in [SHACL, a language for validating RDF graphs](https://datos.gob.es/es/blog/shacl-un-lenguaje-para-validar-grafos-rdf).
+
+    - All versions of the DCAT-AP-ES shapefiles can be found in the code repository: [github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0)
+
+# SHACL shapes of DCAT-AP-ES
+*Non-normative section*
+
+The different validation cases in the DCAT-AP-ES Validator are based on the level of completeness of the checks and the incorporation of background knowledge (vocabularies). Each case is designed for a specific data exchange scenario.
+
+!!! tip "Tip. Use case."
+
+    For most use cases, the [`Case 1: DCAT-AP-ES full`](/validation/#case_1_dcat_ap_es_full) is recommended. It provides a complete validation of basic consistency and conformance to standard vocabularies.
+    If your catalog contains High Value Datasets (HVD), consider using [`Case 2: Full DCAT-AP-ES (HVD)`](/validation/#case_1_dcat_ap_es_full_hvd) for a validation that includes the requirements of the [European Commission Implementing Regulation (EU) 2023/138](https://eur-lex.europa.eu/legal-content/ES/TXT/HTML/?uri=CELEX:32023R0138).
+
+    Choosing the appropriate validation case depends on your specific needs and data exchange context.
+
+Below, each case is described and recommendations are provided on which one to use for a catalog:
+
+## **Case 1: Full DCAT-AP-ES**  {#case_1_dcat_ap_es_full}
+It contains all the necessary constraints for the technical consistency of the different entities of the model, including the constraints of membership to rank classes and all the vocabularies used in DCAT-AP-ES.
+
+*SHACL Shapes*:
+
+- *Standard: Core entities and controlled vocabularies*.
+  - [`shacl_common_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_common_shapes.ttl)
+  - [`shacl_catalog_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_catalog_shapes.ttl)
+  - [`shacl_dataservice_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_dataservice_shapes.ttl)
+  - [`shacl_dataset_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_dataset_shapes.ttl)
+  - [`shacl_distribution_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_distribution_shapes.ttl)
+  - [`shacl_mdr-vocabularies.shape.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_mdr-vocabularies.shape.ttl)
+
+## **Case 2: Full DCAT-AP-ES (HVD)** {#case_2_dcat_ap_es_full_hvd}
+Includes all of the above constraints, plus those to adequately describe high_value datasets ([HVD](/#high_value_datasets_high_value_datasets)).
+
+*SHACL Shapes*: 
+
+- *Standard: Core entities and controlled vocabularies*.
+  - [`shacl_common_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_common_shapes.ttl)
+  - [`shacl_catalog_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_catalog_shapes.ttl)
+  - [`shacl_dataservice_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_dataservice_shapes.ttl)
+  - [`shacl_dataset_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_dataset_shapes.ttl)
+  - [`shacl_distribution_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_distribution_shapes.ttl)
+  - [`shacl_mdr-vocabularies.shape.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_mdr-vocabularies.shape.ttl)
+
+- *HVD: High value datasets specific constraints*
+  - [`shacl_common_hvd_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/hvd/shacl_common_hvd_shapes.ttl)
+  - [`shacl_dataservice_hvd_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/hvd/shacl_dataservice_hvd_shapes.ttl)
+  - [`shacl_dataset_hvd_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/hvd/shacl_dataset_hvd_shapes.ttl)
+  - [`shacl_distribution_hvd_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/hvd/shacl_distribution_hvd_shapes.ttl)
+
+
+## **Case 3: Full DCAT-AP-ES (with background knowlegdge)**  {#case_3_dcat_ap_es_full_imports}
+Extends [Case 1](validation/#case_1_dcat_ap_en_full) with background knowledge and adds conformance to external standards.
+
+*SHACL Shapes*: 
+
+- *Standard: Core entities and controlled vocabularies*
+  - [`shacl_common_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_common_shapes.ttl)
+  - [`shacl_catalog_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_catalog_shapes.ttl)
+  - [`shacl_dataservice_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_dataservice_shapes.ttl)
+  - [`shacl_dataset_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_dataset_shapes.ttl)
+  - [`shacl_distribution_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_distribution_shapes.ttl)
+  - [`shacl_mdr-vocabularies.shape.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_mdr-vocabularies.shape.ttl)
+
+- *Imports*
+  - [`shacl_imports.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_imports.ttl)
+  - [`shacl_mdr_imports.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_mdr_imports.ttl)
+
+## **Caso 4: Full DCAT-AP-ES (HVD with background knowlegdge)** {#case_4_dcat_ap_es_full_hvd_imports}
+Extends [Case 1](validation/#case_1_dcat_ap_en_full) with background knowledge about conformance to external standards. It also includes the forms that allow to properly describe high value datasets ([HVD](#high_value_datasets_high_value_datasets)).
+
+*SHACL Shapes*: 
+
+- *Standard: Core entities and controlled vocabularies*
+  - [`shacl_common_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_common_shapes.ttl)
+  - [`shacl_catalog_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_catalog_shapes.ttl)
+  - [`shacl_dataservice_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_dataservice_shapes.ttl)
+  - [`shacl_dataset_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_dataset_shapes.ttl)
+  - [`shacl_distribution_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_distribution_shapes.ttl)
+  - [`shacl_mdr-vocabularies.shape.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_mdr-vocabularies.shape.ttl)
+
+- *HVD: High value datasets specific constraints*
+  - [`shacl_common_hvd_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/hvd/shacl_common_hvd_shapes.ttl)
+  - [`shacl_dataservice_hvd_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/hvd/shacl_dataservice_hvd_shapes.ttl)
+  - [`shacl_dataset_hvd_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/hvd/shacl_dataset_hvd_shapes.ttl)
+  - [`shacl_distribution_hvd_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/hvd/shacl_distribution_hvd_shapes.ttl)
+
+- *Imports*
+  - [`shacl_imports.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_imports.ttl)
+  - [`shacl_mdr_imports.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_mdr_imports.ttl)
+
+[^1]: Zazuko SHACL Playground: [github.com/zazuko/shacl-playground](https://github.com/zazuko/shacl-playground). Zazuko GmbH.
+[^2]: SHACL validator: [github.com/ISAITB/shacl-validator](https://github.com/ISAITB/shacl-validator). Interoperability Test Bed, Interoperable Europe Unit, DIGIT, European Commission.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,0 +1,102 @@
+![](img/dge_shacl.es.drawio "Ilustración . Descripción de los pasos de validación SHACL")
+
+Para verificar si el intercambio de metadatos cumple técnicamente con [DCAT-AP-ES](/), se pueden utilizar los grafos de [formas SHACL disponibles en el repositorio](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0). El Lenguaje de Restricción de Formas (*Shapes Constraint Language* - SHACL), es una [recomendación del W3C](https://www.w3.org/TR/shacl/]) para expresar restricciones en un grafo de conocimiento RDF. 
+
+Las formas SHACL permiten comprobar si un catálogo expresado en una serialización RDF es válido. Dado que debería ser posible transformar el intercambio de datos en RDF para la conformidad con DCAT-AP-ES, estas formas SHACL pueden utilizarse en cualquier contexto de intercambio de datos. Sin embargo las formas SHACL proporcionadas son solo un punto de partida para los implementadores.
+
+Al utilizar estas plantillas es posible identificar y corregir posibles desviaciones respecto a la especificación, mejorando la calidad de los metadatos producidos. Además, existen herramientas interactivas, como [SHACL playground](https://shacl-playground.zazuko.com/) [^1] o el [Banco de Pruebas de Interoperabilidad de la Comisión Europea](https://www.itb.ec.europa.eu/shacl/any/upload) [^2], que ofrece un servicio en línea donde es posible cargar y validar archivos RDF contra las formas SHACL de DCAT-AP-ES., que facilitan la validación de archivos DCAT-AP utilizando SHACL. ​
+
+!!! info "Información"
+
+    - Más información sobre la validación y las formas SHACL en [SHACL, un lenguaje para validar grafos RDF](https://datos.gob.es/es/blog/shacl-un-lenguaje-para-validar-grafos-rdf).
+
+    - Todas las versiones de los ficheros de formas de DCAT-AP-ES se encuentran en el repositorio de código: [github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0)
+    
+# Formas SHACL de DCAT-AP-ES
+*Sección no normativa*
+
+Los diferentes casos de validación para DCAT-AP-ES se basan en el nivel de completitud de las comprobaciones y en la incorporación de conocimiento de fondo (vocabularios). Cada caso está diseñado para un escenario específico de intercambio de datos.
+
+!!! tip "Consejo. Caso de uso."
+
+    Para la mayoría de los casos de uso, se recomienda el [`Caso 1: DCAT-AP-ES completo`](/validation/#case_1_dcat_ap_es_full). Proporciona una validación completa de la coherencia básica y conformidad con vocabularios estándar.
+    Si tu catálogo contiene conjuntos de datos de alto valor (HVD), considera utilizar el [`Caso 2: DCAT-AP-ES completo (HVD)`](/validation/#case_1_dcat_ap_es_full_hvd) para una validación que incluya los requerimientos del [Reglamento de ejecución (UE) 2023/138 de la Comisión Europea](https://eur-lex.europa.eu/legal-content/ES/TXT/HTML/?uri=CELEX:32023R0138).
+
+    La elección del caso de validación adecuado depende de tus necesidades específicas y del contexto de intercambio de datos.
+
+A continuación, se describe cada caso con las formas para la versión `DCAT-AP-ES 1.0.0` y se recomienda cuál utilizar para un catálogo:
+
+## **Caso 1: DCAT-AP-ES completo** {#case_1_dcat_ap_es_full}
+Incluye todas las restricciones necesarias para la coherencia técnica de las distintas entidades del modelo, incluyendo las restricciones de pertenencia a clases de rango y todos los vocabularios utilizados en DCAT-AP-ES.
+
+*Formas SHACL*:
+
+- *Estándar*
+  - [`shacl_common_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_common_shapes.ttl)
+  - [`shacl_catalog_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_catalog_shapes.ttl)
+  - [`shacl_dataservice_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_dataservice_shapes.ttl)
+  - [`shacl_dataset_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_dataset_shapes.ttl)
+  - [`shacl_distribution_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_distribution_shapes.ttl)
+  - [`shacl_mdr-vocabularies.shape.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_mdr-vocabularies.shape.ttl)
+
+## **Caso 2: DCAT-AP-ES completo (HVD)** {#case_2_dcat_ap_es_full_hvd}
+Incluye todas las restricciones anteriormente mencionadas, además de aquellas que permiten describir adecuadamente los conjuntos de datos de alto valor ([HVD](/#conjuntos_de_datos_de_alto_valor_high_value_datasets)).
+
+*Formas SHACL*:
+
+- *Estándar: Entidades principales y vocabularios controlados*
+  - [`shacl_common_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_common_shapes.ttl)
+  - [`shacl_catalog_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_catalog_shapes.ttl)
+  - [`shacl_dataservice_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_dataservice_shapes.ttl)
+  - [`shacl_dataset_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_dataset_shapes.ttl)
+  - [`shacl_distribution_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_distribution_shapes.ttl)
+  - [`shacl_mdr-vocabularies.shape.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_mdr-vocabularies.shape.ttl)
+
+- *HVD: Restricciones específicas de conjuntos de alto valor*
+  - [`shacl_common_hvd_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/hvd/shacl_common_hvd_shapes.ttl)
+  - [`shacl_dataservice_hvd_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/hvd/shacl_dataservice_hvd_shapes.ttl)
+  - [`shacl_dataset_hvd_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/hvd/shacl_dataset_hvd_shapes.ttl)
+  - [`shacl_distribution_hvd_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/hvd/shacl_distribution_hvd_shapes.ttl)
+
+## **Caso 3: DCAT-AP-ES completo (con conocimiento de fondo)** {#case_3_dcat_ap_es_full_imports}
+Extiende el [Caso 1](validation/#case_1_dcat_ap_es_full) con conocimiento de fondo, añadiendo conformidad con estándares externos.
+
+*Formas SHACL*:
+
+- *Estándar: Entidades principales y vocabularios controlados*
+  - [`shacl_common_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_common_shapes.ttl)
+  - [`shacl_catalog_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_catalog_shapes.ttl)
+  - [`shacl_dataservice_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_dataservice_shapes.ttl)
+  - [`shacl_dataset_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_dataset_shapes.ttl)
+  - [`shacl_distribution_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_distribution_shapes.ttl)
+  - [`shacl_mdr-vocabularies.shape.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_mdr-vocabularies.shape.ttl)
+
+- *Importaciones*
+  - [`shacl_imports.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_imports.ttl)
+  - [`shacl_mdr_imports.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_mdr_imports.ttl)
+
+## **Caso 4: DCAT-AP-ES completo (HVD con conocimiento de fondo)** {#case_4_dcat_ap_es_full_hvd_imports}
+Extiende el [Caso 1](validation/#case_1_dcat_ap_es_full) con conocimiento de fondo conformidad con estándares externos. También incluye las formas que permiten describir adecuadamente los conjuntos de datos de alto valor ([HVD](#conjuntos_de_datos_de_alto_valor_high_value_datasets)).
+
+*Formas SHACL*:
+
+- *Estándar: Entidades principales y vocabularios controlados*
+  - [`shacl_common_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_common_shapes.ttl)
+  - [`shacl_catalog_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_catalog_shapes.ttl)
+  - [`shacl_dataservice_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_dataservice_shapes.ttl)
+  - [`shacl_dataset_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_dataset_shapes.ttl)
+  - [`shacl_distribution_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_distribution_shapes.ttl)
+  - [`shacl_mdr-vocabularies.shape.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_mdr-vocabularies.shape.ttl)
+
+- *HVD: Restricciones específicas de conjuntos de alto valor*
+  - [`shacl_common_hvd_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/hvd/shacl_common_hvd_shapes.ttl)
+  - [`shacl_dataservice_hvd_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/hvd/shacl_dataservice_hvd_shapes.ttl)
+  - [`shacl_dataset_hvd_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/hvd/shacl_dataset_hvd_shapes.ttl)
+  - [`shacl_distribution_hvd_shapes.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/hvd/shacl_distribution_hvd_shapes.ttl)
+
+- *Importaciones*
+  - [`shacl_imports.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_imports.ttl)
+  - [`shacl_mdr_imports.ttl`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/1.0.0/shacl_mdr_imports.ttl)
+
+[^1]: Zazuko SHACL Playground: [github.com/zazuko/shacl-playground](https://github.com/zazuko/shacl-playground). Zazuko GmbH.
+[^2]: SHACL validator: [github.com/ISAITB/shacl-validator](https://github.com/ISAITB/shacl-validator). Interoperability Test Bed, Interoperable Europe Unit, DIGIT, European Commission.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,8 +16,8 @@ nav:
   - Guía técnica DCAT-AP-ES: index.md
   - Convenciones datos.gob.es: conventions.md
   - FAQ: faq.md
+  - Validación: validation.md
   - Ejemplos: examples.md
-  #- Validación: validation.md
 
 theme:
   language: es
@@ -169,8 +169,8 @@ plugins:
           - DCAT-AP-ES technical guide: index.md
           - datos.gob.es conventions: conventions.en.md
           - FAQ: faq.en.md
+          - Validation: validation.en.md
           - Examples: examples.en.md
-          #- DCAT-AP-ES validation: validation.en.md
   - mkdocstrings:
       handlers:
         python:
@@ -192,6 +192,9 @@ plugins:
         'convenciones.md': 'conventions.md'
         'ejemplos.md': 'examples.md'
         'preguntas-frecuentes.md': 'faq.md'
+        'validacion.md': 'validation.md'
+        'validación.md': 'validation.md'
+        'mqa.md': 'validation.md'
   - minify:
       minify_html: true
   - social:
@@ -214,7 +217,7 @@ plugins:
       toolbar: true 
       tooltips: true
       edit: true
-      border: 0
+      border: 1
   - meta-descriptions
 watch:
 - refs/docs


### PR DESCRIPTION
- Creados nuevos archivos de documentación para la validación SHACL tanto en inglés (validation.en.md) como en español (validation.md).
- Actualizado mkdocs.yml para incluir la nueva documentación de validación en la navegación para ambos idiomas.
- Se han añadido descripciones detalladas de las formas SHACL y los casos de validación para DCAT-AP-ES, incluidos enlaces a los recursos y formas SHACL pertinentes.