### PR TITLE
Refactorización de los archivos de validación SHACL

### DIFF
--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -60,17 +60,17 @@ Below, generic vocabularies that configure the namespaces reused in the implemen
 | **Vocabulary** | **Prefix** | **URI** |
 | --- | --- | --- |
 | Asset Description Metadata Schema | `adms:` | `http://www.w3.org/ns/adms#` |
-| Dataset Catalog (dcat) | `dcat:` | `http://www.w3.org/ns/dcat#` |
+| Data Catalog Vocabulary | `dcat:` | `http://www.w3.org/ns/dcat#` |
 | DCAT Application profile for data portals | `dcatap:` | `http://data.europa.eu/r5r/` |
 | Dublin Core Terms | `dct:` | `http://purl.org/dc/terms/` |
-| Friend Of A Friend (FOAF) | `foaf:` | `http://xmlns.com/foaf/0.1/` |
+| Friend Of A Friend  | `foaf:` | `http://xmlns.com/foaf/0.1/` |
 | Location Core Vocabulary | `locn:` | `http://www.w3.org/ns/locn#` |
 | Web Ontology Document | `owl:` | `http://www.w3.org/2002/07/owl#` |
 | Open Digital Rights Language | `odrl:` | `http://www.w3.org/ns/odrl/2/` |
 | Prov Family of Documents | `prov:` | `http://www.w3.org/ns/prov#` |
 | Resource Description Framework | `rdf:` | `http://www.w3.org/1999/02/22-rdf-syntax-ns#` |
 | Resource Description Framework Schema | `rdfs:` | `http://www.w3.org/2000/01/rdf-schema#` |
-| Simple Knowledge Organization System (SKOS) | `skos:` | `http://www.w3.org/2004/02/skos/core#` |
+| Simple Knowledge Organization System | `skos:` | `http://www.w3.org/2004/02/skos/core#` |
 | Software Package Data Exchange | `spdx:` | `http://spdx.org/rdf/terms#` |
 | W3C Time Ontology | `time:` | `http://www.w3.org/2006/time#` |
 | vCard Ontology | `vcard:` | `http://www.w3.org/2006/vcard/ns#` |

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,17 +61,17 @@ Se enumerarán a continuación vocabularios genéricos que configuran el espacio
 | **Vocabulario** | **Prefijo** | **URI** |
 | --- | --- | --- |
 | Asset Description Metadata Schema | `adms:` | `http://www.w3.org/ns/adms#` |
-| Dataset Catalog (dcat) | `dcat:` | `http://www.w3.org/ns/dcat#` |
+| Data Catalog Vocabulary | `dcat:` | `http://www.w3.org/ns/dcat#` |
 | DCAT Application profile for data portals | `dcatap:` | `http://data.europa.eu/r5r/` |
 | Dublin Core Terms | `dct:` | `http://purl.org/dc/terms/` |
-| Friend Of A Friend (FOAF) | `foaf:` | `http://xmlns.com/foaf/0.1/` |
+| Friend Of A Friend | `foaf:` | `http://xmlns.com/foaf/0.1/` |
 | Location Core Vocabulary | `locn:` | `http://www.w3.org/ns/locn#` |
 | Web Ontology Document | `owl:` | `http://www.w3.org/2002/07/owl#` |
 | Open Digital Rights Language | `odrl:` | `http://www.w3.org/ns/odrl/2/` |
 | Prov Family of Documents | `prov:` | `http://www.w3.org/ns/prov#` |
 | Resource Description Framework | `rdf:` | `http://www.w3.org/1999/02/22-rdf-syntax-ns#` |
 | Resource Description Framework Schema | `rdfs:` | `http://www.w3.org/2000/01/rdf-schema#` |
-| Simple Knowledge Organization System (SKOS) | `skos:` | `http://www.w3.org/2004/02/skos/core#` |
+| Simple Knowledge Organization System | `skos:` | `http://www.w3.org/2004/02/skos/core#` |
 | Software Package Data Exchange | `spdx:` | `http://spdx.org/rdf/terms#` |
 | W3C Time Ontology | `time:` | `http://www.w3.org/2006/time#` |
 | vCard Ontology | `vcard:` | `http://www.w3.org/2006/vcard/ns#` |

--- a/refs/docs/abbreviations.md
+++ b/refs/docs/abbreviations.md
@@ -8,6 +8,7 @@
 *[DOI]: Digital Object Identifier
 *[ELI]: European Legislation Identifier
 *[FAQ]: Preguntas frecuentes
+*[FOAF]: Friend Of A Friend
 *[HVD]: High Value Datasets
 *[IANA]: Internet Assigned Numbers Authority
 *[INSPIRE]: Infrastructure for Spatial Information in Europe

--- a/shacl/1.0.0/hvd/shacl_common_hvd_shapes.ttl
+++ b/shacl/1.0.0/hvd/shacl_common_hvd_shapes.ttl
@@ -1,5 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix : <http://datos.gob.es/dcat-ap-es#> .
 @prefix cc: <http://creativecommons.org/ns#> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dct: <http://purl.org/dc/terms/> .
@@ -39,7 +38,7 @@
 #--------------------------
 # Common for HVD restrictions
 #--------------------------
-:HVDCategory_HVDRestriction
+dcatapes:HVDCategory_HVDRestriction
     a sh:NodeShape ;
     rdfs:comment "Shape reservado para futuras restricciones específicas de categorías HVD."@es ;
     rdfs:comment "Shape reserved for future specific restrictions on HVD categories."@en ;

--- a/shacl/1.0.0/hvd/shacl_dataservice_hvd_shape.ttl
+++ b/shacl/1.0.0/hvd/shacl_dataservice_hvd_shape.ttl
@@ -1,5 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix : <http://datos.gob.es/dcat-ap-es#> .
 @prefix cc: <http://creativecommons.org/ns#> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dct: <http://purl.org/dc/terms/> .
@@ -47,7 +46,7 @@
 # dcat:DataService HVD restrictions
 #--------------------------
 # Convencion 12
-:DataService_HVD_Shape
+dcatapes:DataService_HVD_Shape
     a sh:NodeShape ;
     sh:name "Servicio de Datos HVD"@en ;
     sh:name "HVD Data Service"@en ;
@@ -69,7 +68,7 @@
     ],
     [
         sh:path dcatap:hvdCategory;
-        sh:node :HVDCategoryRestriction ;
+        sh:node dcatapes:HVDCategoryRestriction ;
     ],
 
     # dcat:contactPoint
@@ -139,7 +138,7 @@
     ], 
     [
         sh:path dcatap:hvdCategory;
-        sh:node :HVDCategoryRestriction ;
+        sh:node dcatapes:HVDCategoryRestriction ;
         sh:severity sh:Violation ;
     ],
 

--- a/shacl/1.0.0/hvd/shacl_dataset_hvd_shape.ttl
+++ b/shacl/1.0.0/hvd/shacl_dataset_hvd_shape.ttl
@@ -1,5 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix : <http://datos.gob.es/dcat-ap-es#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix cc: <http://creativecommons.org/ns#> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
@@ -54,7 +53,7 @@
 #--------------------------
 # dcat:Dataset HVD restrictions
 #--------------------------
-:Dataset_HVD_Shape
+dcatapes:Dataset_HVD_Shape
     a sh:NodeShape ;
     sh:name "Conjunto de datos HVD"@en ;
     sh:name "HVD Dataset"@en ;
@@ -111,6 +110,6 @@
     ],
     [
         sh:path dcatap:hvdCategory ;
-        sh:node :HVDCategoryRestriction ;
+        sh:node dcatapes:HVDCategoryRestriction ;
     ];
     sh:targetClass dcat:Dataset .

--- a/shacl/1.0.0/hvd/shacl_distribution_hvd_shape.ttl
+++ b/shacl/1.0.0/hvd/shacl_distribution_hvd_shape.ttl
@@ -1,5 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix : <http://datos.gob.es/dcat-ap-es#> .
 @prefix cc: <http://creativecommons.org/ns#> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dct: <http://purl.org/dc/terms/> .
@@ -46,7 +45,7 @@
 #--------------------------
 # dcat:Distribution HVD restrictions
 #--------------------------
-:Distribution_HVD_Shape
+dcatapes:Distribution_HVD_Shape
     a sh:NodeShape ;
     sh:name "Distribución HVD"@en ;
     sh:name "HVD Distribution"@en ;

--- a/shacl/1.0.0/shacl_catalog_shape.ttl
+++ b/shacl/1.0.0/shacl_catalog_shape.ttl
@@ -1,5 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix : <https://datosgobes.github.io/DCAT-AP-ES/> .
 @prefix cc: <http://creativecommons.org/ns#> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dct: <http://purl.org/dc/terms/> .
@@ -44,7 +43,7 @@
 #--------------------------
 # dcat:Catalog restrictions
 #--------------------------
-:Catalog_Shape
+dcatapes:Catalog_Shape
     a sh:NodeShape ;
     sh:name "Catálogo"@en ;
     sh:name "Catalog"@en ;
@@ -65,18 +64,21 @@
     ], 
     [
         sh:path dct:title ;
-        sh:node :LiteralMultilingualConvention ; 
+        sh:node dcatapes:LiteralMultilingualConvention ; 
         sh:severity sh:Violation ;
     ],
     [
         sh:path dct:title ;
-        sh:node :NonEmptyLiteralConvention ; 
+        sh:node dcatapes:NonEmptyLiteralConvention ; 
         sh:severity sh:Violation ;
     ],
     [
         sh:path dct:title ;
-        sh:node :UniqueLangLiteralRestriction ;
+        sh:uniqueLang true;
         sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
+        sh:message "Más de un valor comparten la misma etiqueta de idioma. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@es ;
+        sh:message "More than one value shares the same language tag. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@en ;
     ],
 
     # dct:description
@@ -90,18 +92,21 @@
     ], 
     [
         sh:path dct:description ;
-        sh:node :LiteralMultilingualConvention ; 
+        sh:node dcatapes:LiteralMultilingualConvention ; 
         sh:severity sh:Violation ;
     ],
     [
         sh:path dct:description ;
-        sh:node :NonEmptyLiteralConvention ; 
+        sh:node dcatapes:NonEmptyLiteralConvention ; 
         sh:severity sh:Violation ;
     ],
     [
         sh:path dct:description ;
-        sh:node :UniqueLangLiteralRestriction ;
+        sh:uniqueLang true;
         sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
+        sh:message "Más de un valor comparten la misma etiqueta de idioma. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@es ;
+        sh:message "More than one value shares the same language tag. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@en ;
     ],
 
     # dct:publisher
@@ -123,7 +128,7 @@
     ],
     [
         sh:path dct:publisher ;
-        sh:node :DIR3OrganismRestriction;
+        sh:node dcatapes:DIR3OrganismRestriction;
         sh:or(
             [
                 sh:nodeKind sh:IRI; 
@@ -131,8 +136,8 @@
             ]
             [
                 sh:nodeKind sh:BlankNodeOrIRI;
-                sh:node :Agent_Shape;
-                sh:node :PublisherAgentRestriction;
+                sh:node dcatapes:Agent_Shape;
+                sh:node dcatapes:PublisherAgentRestriction;
             ]
         );
         sh:severity sh:Violation ;
@@ -149,7 +154,7 @@
             ]
             [
                 sh:nodeKind sh:BlankNodeOrIRI;
-                sh:node :Agent_ShapeRecommended
+                sh:node dcatapes:Agent_ShapeRecommended
             ]
         );
         sh:severity sh:Warning;
@@ -232,7 +237,7 @@
         sh:path dct:issued ;
         sh:maxCount 1 ;
         sh:nodeKind sh:Literal ;
-        sh:node :DateOrDateTimeDataTypetConvention ;
+        sh:node dcatapes:DateOrDateTimeDataTypetConvention ;
         sh:severity sh:Violation ;
     ],
     [
@@ -249,7 +254,7 @@
         sh:path dct:modified ;
         sh:maxCount 1 ;
         sh:nodeKind sh:Literal ;
-        sh:node :DateOrDateTimeDataTypetConvention ;
+        sh:node dcatapes:DateOrDateTimeDataTypetConvention ;
         sh:severity sh:Violation ;
     ],
     [
@@ -264,7 +269,7 @@
     # dct:language
     [
         sh:path dct:language ;
-        sh:node :LanguageRestriction ;
+        sh:node dcatapes:LanguageRestriction ;
         sh:severity sh:Violation ;
     ], 
     [
@@ -296,8 +301,8 @@
     [
         sh:path dct:license ;
         sh:or (
-            [ sh:node :LicenceDocumentRestriction ;]
-            [ sh:node :LicenceRestriction ;]
+            [ sh:node dcatapes:LicenceDocumentRestriction ;]
+            [ sh:node dcatapes:LicenceRestriction ;]
             [ sh:nodeKind sh:IRI ;]
         );
         sh:severity sh:Violation ;
@@ -338,10 +343,10 @@
             [ 
                 sh:class dct:Location ;
                 # WKT restriction
-                sh:node :SpatialGeometryConvention ; 
+                sh:node dcatapes:SpatialGeometryConvention ; 
             ]
             [ 
-                sh:node :Spatial_Shape ;
+                sh:node dcatapes:Spatial_Shape ;
                 sh:nodeKind sh:IRI ;
                 sh:severity sh:Violation;
             ]
@@ -382,8 +387,8 @@
             ]
             [
                 sh:nodeKind sh:BlankNodeOrIRI;
-                sh:node :Agent_Shape;
-                sh:node :CreatorAgentRestriction;
+                sh:node dcatapes:Agent_Shape;
+                sh:node dcatapes:CreatorAgentRestriction;
             ]
         );
         sh:severity sh:Violation ;
@@ -397,7 +402,7 @@
             ]
             [
                 sh:nodeKind sh:BlankNodeOrIRI;
-                sh:node :Agent_ShapeRecommended
+                sh:node dcatapes:Agent_ShapeRecommended
             ]
         );
         sh:severity sh:Warning ;
@@ -451,7 +456,7 @@
     foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#dcat-catalog> ;
     sh:targetClass dcat:Catalog .
 
-:CatalogDatasetOrServiceRestriction
+dcatapes:CatalogDatasetOrServiceRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que un catálogo tenga al menos un conjunto de datos (dcat:dataset) o un servicio de datos (dcat:service)."@es ;
     rdfs:comment "Restriction to validate that a catalog has at least one dataset (dcat:dataset) or one data service (dcat:service)."@en ;
@@ -479,7 +484,7 @@
     sh:targetClass dcat:Catalog .
 
 # Convencion 02
-:CatalogSPALanguageRestriction
+dcatapes:CatalogSPALanguageRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que un catálogo cumpla con las convenciones de idioma y contenido en español, incluyendo título, descripción y otros elementos clave."@es ;
     rdfs:comment "Restriction to validate that a catalog complies with Spanish language and content conventions, including title, description, and other key elements."@en ;
@@ -487,9 +492,9 @@
     rdfs:label "Catalog restriction: Spanish language and content"@en ;
     sh:name "Catalog Spanish Language and Content Restriction"@en ;
     sh:name "Restricción de catálogo para idioma y contenido en español"@en ;
-    sh:node :SpanishLanguageRestriction ;
-    sh:node :SpanishTitleRestriction ;
-    sh:node :SpanishDescriptionRestriction ;
+    sh:node dcatapes:SpanishLanguageRestriction ;
+    sh:node dcatapes:SpanishTitleRestriction ;
+    sh:node dcatapes:SpanishDescriptionRestriction ;
     sh:severity sh:Violation ;
     foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
     sh:targetClass dcat:Catalog .

--- a/shacl/1.0.0/shacl_common_shapes.ttl
+++ b/shacl/1.0.0/shacl_common_shapes.ttl
@@ -1,5 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix : <http://datos.gob.es/dcat-ap-es#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix cc: <http://creativecommons.org/ns#> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
@@ -45,7 +44,7 @@
 #--------------------------
 # Common restrictions
 #--------------------------
-:Agent_Shape
+dcatapes:Agent_Shape
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que un agente tenga un nombre, un identificador y un tipo válidos, cumpliendo con las reglas de DCAT-AP-ES."@es ;
     rdfs:comment "Restriction to validate that an agent has a valid name, identifier, and type, complying with DCAT-AP-ES rules."@en ;
@@ -63,7 +62,7 @@
     ],
     [
         sh:path foaf:name ;
-        sh:node :LiteralMultilingualConvention ;
+        sh:node dcatapes:LiteralMultilingualConvention ;
         sh:severity sh:Violation ;
         foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-foaf_agent-foaf_name> ;
         sh:message "El nombre del agente debe ser multilingüe."@es ;
@@ -71,7 +70,7 @@
     ],
     [
         sh:path foaf:name ;
-        sh:node :NonEmptyLiteralConvention ;
+        sh:node dcatapes:NonEmptyLiteralConvention ;
         sh:severity sh:Violation ;
         foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-foaf_agent-foaf_name> ;
         sh:message "El nombre del agente no puede estar vacío."@es ;
@@ -125,7 +124,7 @@
     ],
     [
         sh:path dct:identifier ;
-        sh:node :NonEmptyLiteralConvention ;
+        sh:node dcatapes:NonEmptyLiteralConvention ;
         sh:severity sh:Violation ;
         foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-foaf_agent-dct_identifier> ;
         sh:message "El identificador del agente no puede estar vacío."@es ;
@@ -153,13 +152,13 @@
     [
         sh:path dct:type ;
         sh:nodeKind sh:IRI ;
-        sh:node :PublisherTypeRestriction ;
+        sh:node dcatapes:PublisherTypeRestriction ;
         sh:description "Se utiliza un concepto no gestionado por la UE para indicar el tipo del agente. Si no se encuentra uno correspondiente, informe al mantenedor de la lista de códigos adms:publishertype."@es ;
         sh:description "A non-EU managed concept is used to indicate the type of the agent. If no corresponding one can be found, inform the maintainer of the adms:publishertype codelist."@en ;
         sh:severity sh:Violation ;
     ] .
 
-:Agent_ShapeRecommended
+dcatapes:Agent_ShapeRecommended
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que un agente tenga al menos un identificador y un tipo, cumpliendo con las reglas de DCAT-AP-ES."@es ;
     rdfs:comment "Restriction to validate that an agent has at least one identifier and one type, complying with DCAT-AP-ES rules."@en ;
@@ -191,7 +190,7 @@
     sh:message "Se recomienda que el agente tenga al menos un identificador y un tipo."@es ;
     sh:message "It is recommended that the agent has at least one identifier and one type."@en .
 
-:PublisherAgentRestriction
+dcatapes:PublisherAgentRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que el tipo del nodo sea foaf:Agent o foaf:Organization."@es ;
     rdfs:comment "Restriction to validate that the node type is foaf:Agent or foaf:Organization."@en ;
@@ -206,7 +205,7 @@
     sh:message "El tipo del nodo debe ser un foaf:Agent o foaf:Organization."@es ;
     sh:message "The node type must be foaf:Agent or foaf:Organization."@en .
 
-:CreatorAgentRestriction
+dcatapes:CreatorAgentRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que el creador de un recurso sea un agente válido, ya sea una persona, una organización o un agente genérico, cumpliendo con las reglas de DCAT-AP-ES."@es ;
     rdfs:comment "Restriction to validate that the creator of a resource is a valid agent, either a person, an organization, or a generic agent, complying with DCAT-AP-ES rules."@en ;
@@ -230,7 +229,7 @@
     sh:message "El tipo del nodo debe ser foaf:Agent, foaf:Organization o foaf:Person."@es ;
     sh:message "The node type must be foaf:Agent, foaf:Organization, or foaf:Person."@en .
 
-:SingleIRIRestriction
+dcatapes:SingleIRIRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción genérica para validar que una propiedad tenga un IRI válido."@es ;
     rdfs:comment "Generic restriction to validate that a property has a valid IRI."@en ;
@@ -242,7 +241,7 @@
     sh:message "The property must be a valid IRI."@en .
 
 # Convencion 08
-:DateOrDateTimeDataTypetConvention
+dcatapes:DateOrDateTimeDataTypetConvention
     a sh:NodeShape ;
     rdfs:comment "Convención para validar que un valor temporal sea de tipo xsd:dateTime, xsd:date, xsd:gYearMonth o xsd:gYear, siguiendo el formato ISO-8601."@es ;
     rdfs:comment "Convention to validate that a temporal value is of type xsd:dateTime, xsd:date, xsd:gYearMonth, or xsd:gYear, following the ISO-8601 format."@en ;
@@ -281,7 +280,7 @@
     ) ;
     sh:severity sh:Violation .
 
-:DurationRestriction
+dcatapes:DurationRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que un valor de duración siga el formato ISO 8601 para xsd:duration (por ejemplo, P3Y6M4DT12H30M5S)."@es ;
     rdfs:comment "Restriction to validate that a duration value follows the ISO 8601 format for xsd:duration (e.g., P3Y6M4DT12H30M5S)."@en ;
@@ -297,7 +296,7 @@
     sh:message "The duration value must follow the ISO 8601 format for xsd:duration (e.g., P3Y6M4DT12H30M5S)."@en ;
     sh:severity sh:Violation .
 
-:EuropeanDataThemeRestriction
+dcatapes:EuropeanDataThemeRestriction
     a sh:NodeShape ;
     rdfs:comment "European Data Theme Restriction"@en ;
     rdfs:label "European Data Theme Restriction"@en ;
@@ -308,7 +307,7 @@
     sh:message "The value must be an IRI from the European inspire vocabulary http://publications.europa.eu/resource/authority/data-theme."@en ;
     sh:severity sh:Violation.
 
-:InspireDataThemeRestriction
+dcatapes:InspireDataThemeRestriction
     a sh:NodeShape ;
     rdfs:comment "Inspire Data Theme Restriction"@en ;
     rdfs:label "Inspire Data Theme Restriction"@en ;
@@ -320,7 +319,7 @@
     sh:severity sh:Violation.
 
 # Convencion 19
-:VcardKindMinimalConvention
+dcatapes:VcardKindMinimalConvention
     a sh:NodeShape ;
     rdfs:comment "Convención para recomendar que un nodo conectado mediante dcat:contactPoint utilice vcard:fn, vcard:hasTelephone y vcard:hasUID, cumpliendo con las reglas de DCAT-AP-ES."@es ;
     rdfs:comment "Convention to recommend that a node connected via dcat:contactPoint uses vcard:fn, vcard:hasTelephone, and vcard:hasUID, complying with DCAT-AP-ES rules."@en ;
@@ -356,7 +355,7 @@
     sh:message "It is recommended that the contact point uses vcard:fn, vcard:hasTelephone, and vcard:hasUID. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-19"@en ;
     sh:severity sh:Warning .
 
-:VcardKindRestriction
+dcatapes:VcardKindRestriction
     rdfs:comment "Restricción para validar que un nodo conectado mediante dcat:contactPoint sea de tipo vcard:Kind o una de sus subclases, cumpliendo con las reglas de DCAT-AP-ES."@es ;
     rdfs:comment "Restriction to validate that a node connected via dcat:contactPoint is of type vcard:Kind or one of its subclasses, complying with DCAT-AP-ES rules."@en ;
     rdfs:label "Restricción para vcard:Kind y subclases"@es ;
@@ -381,12 +380,12 @@
     ],
     [
         sh:path vcard:organization-name ;
-        sh:node :NonEmptyLiteralConvention;
+        sh:node dcatapes:NonEmptyLiteralConvention;
         sh:severity sh:Violation ;
     ],
     [
         sh:path vcard:organization-name ;
-        sh:node :LiteralMultilingualConvention;
+        sh:node dcatapes:LiteralMultilingualConvention;
         sh:severity sh:Violation ;
     ],
     [
@@ -398,8 +397,11 @@
     ],
     [
         sh:path vcard:organization-name ;
-        sh:node :UniqueLangLiteralRestriction ;
+        sh:uniqueLang true;
         sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
+        sh:message "Más de un valor comparten la misma etiqueta de idioma. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@es ;
+        sh:message "More than one value shares the same language tag. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@en ;
     ],
     [
         sh:path vcard:organization-name ;        
@@ -432,18 +434,21 @@
     ], 
     [
         sh:path vcard:fn ;
-        sh:node :LiteralMultilingualConvention ;
+        sh:node dcatapes:LiteralMultilingualConvention ;
         sh:severity sh:Violation ;
     ],
     [
         sh:path vcard:fn ;
-        sh:node :NonEmptyLiteralConvention ;
+        sh:node dcatapes:NonEmptyLiteralConvention ;
         sh:severity sh:Violation ;
     ],
     [
         sh:path vcard:fn ;
-        sh:node :UniqueLangLiteralRestriction ;
+        sh:uniqueLang true;
         sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
+        sh:message "Más de un valor comparten la misma etiqueta de idioma. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@es ;
+        sh:message "More than one value shares the same language tag. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@en ;
     ],
     [
         sh:path vcard:fn ;
@@ -556,7 +561,7 @@
     ].
     #sh:targetClass vcard:Kind .
 
-:VcardKindRestriction2
+dcatapes:VcardKindRestriction2
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que un nodo conectado mediante dcat:contactPoint sea de tipo vcard:Kind o una de sus subclases, y que contenga al menos un vcard:hasEmail o un vcard:hasURL, cumpliendo con las reglas de DCAT-AP-ES."@es ;
     rdfs:comment "Restriction to validate that a node connected via dcat:contactPoint is of type vcard:Kind or one of its subclasses, and contains at least one vcard:hasEmail or vcard:hasURL, complying with DCAT-AP-ES rules."@en ;
@@ -593,7 +598,7 @@
     sh:message "At least one of vcard:hasEmail or vcard:hasURL must be provided."@en ;
     sh:severity sh:Violation .
 
-:LicenceDocumentRestriction
+dcatapes:LicenceDocumentRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que un documento de licencia tenga un tipo definido y que este sea un IRI válido del vocabulario de tipos de licencia."@es ;
     rdfs:comment "Restriction to validate that a license document has a defined type and that it is a valid IRI from the license type vocabulary."@en ;
@@ -612,7 +617,7 @@
     ],
     [
         sh:path dct:type ;
-        sh:node :LicenceTypeRestriction ;
+        sh:node dcatapes:LicenceTypeRestriction ;
         sh:nodeKind sh:IRI ;
         sh:severity sh:Violation ;
         foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dct_license> ;
@@ -622,7 +627,7 @@
     sh:targetClass dct:LicenseDocument .
 
 # Convencion 01:
-:LiteralMultilingualConvention
+dcatapes:LiteralMultilingualConvention
     a sh:NodeShape;
     rdfs:comment "Restricción para validar que un literal sea multilingüe, es decir, que tenga una etiqueta de idioma."@es ;
     rdfs:comment "Restriction to validate that a literal is multilingual, meaning it must have a language tag."@en ;
@@ -635,7 +640,7 @@
     sh:message "The literal must be multilingual. It must have a language tag. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-01"@en ;
     sh:severity sh:Violation .
 
-:Location_Shape
+dcatapes:Location_Shape
     a sh:NodeShape ;
     sh:name "Location"@en ;
     # At least one or properties have to be
@@ -682,7 +687,7 @@
     sh:targetClass dct:Location .
 
 # Convencion 02
-:NonEmptyLiteralConvention
+dcatapes:NonEmptyLiteralConvention
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que un literal no esté vacío ni contenga solo caracteres en blanco, tabulaciones o saltos de línea."@es ;
     rdfs:comment "Restriction to validate that a literal is not empty or does not contain only whitespace characters, tabs, or line breaks."@en ;
@@ -699,21 +704,7 @@
     sh:severity sh:Violation .
 
 # Convención 02
-:UniqueLangLiteralRestriction
-    a sh:NodeShape ;
-    rdfs:comment "Restricción para validar que los valores de un literal no compartan la misma etiqueta de idioma."@es ;
-    rdfs:comment "Restriction to validate that the values of a literal do not share the same language tag."@en ;
-    rdfs:label "Restricción para literales con etiquetas de idioma únicas"@es ;
-    rdfs:label "Unique Language Tag Literal Restriction"@en ;
-    sh:name "Unique Language Tag Literal"@en ;
-    sh:uniqueLang true ;
-    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
-    sh:message "Más de un valor comparten la misma etiqueta de idioma. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@es ;
-    sh:message "More than one value shares the same language tag. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@en ;
-    sh:severity sh:Violation .
-
-# Convención 02
-:NonLiteralMultilingualConvention
+dcatapes:NonLiteralMultilingualConvention
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que un literal no sea multilingüe, es decir, que no tenga una etiqueta de idioma."@es ;
     rdfs:comment "Restriction to validate that a literal is not multilingual, meaning it must not have a language tag."@en ;
@@ -728,7 +719,7 @@
     sh:message "The literal cannot be multilingual. It must not have a language tag. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-04"@en ;
     sh:severity sh:Violation .
 
-:NonNegativeIntegerRestriction
+dcatapes:NonNegativeIntegerRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que un valor sea un número entero no negativo, incluyendo cero."@es ;
     rdfs:comment "Restriction to validate that a value is a non-negative integer, including zero."@en ;
@@ -751,7 +742,7 @@
     sh:message "The value must be a non-negative integer."@en ;
     sh:severity sh:Violation .
 
-:PublicSectorRestriction
+dcatapes:PublicSectorRestriction
     a sh:NodeShape ;
     rdfs:comment "NTI-RISP sector vocabulary restriction."@en ;
     rdfs:comment "Restricción del vocabulario de sectores de la NTI."@es ;
@@ -790,7 +781,7 @@
 
 
 #Generic shape to validate that Spanish description is required
-:SpanishDescriptionRestriction
+dcatapes:SpanishDescriptionRestriction
     a sh:NodeShape ;
     sh:name "SpanishDescriptionRestriction"@en ;
     rdfs:comment "The description in spanish is required"@en ;
@@ -812,7 +803,7 @@
     sh:severity sh:Violation .
 
 #Generic shape to validate that Spanish language is required
-:SpanishLanguageRestriction
+dcatapes:SpanishLanguageRestriction
     a sh:NodeShape ;
     sh:name "SpanishlanguageRestriction"@en ;
     rdfs:comment "The Spanish language is required"@en ;
@@ -832,29 +823,27 @@
         sh:severity sh:Violation ;
     ] .
 
-#Generic shape to validate that Spanish title is required
-:SpanishTitleRestriction
+dcatapes:SpanishTitleRestriction
     a sh:NodeShape ;
-    sh:name "SpanishlanguageRestriction"@en ;
-    rdfs:comment "The title in spanish is required"@en ;
-    rdfs:label "Spanish title Restriction"@en ;
-    sh:sparql [
-            sh:message "The title value must be at least in Spanish."@en ;
-            sh:select """
-                PREFIX dct: <http://purl.org/dc/terms/>
-                SELECT $this
-                WHERE {
-                FILTER EXISTS { $this dct:title ?value }
-                FILTER NOT EXISTS {
-                    $this dct:title ?value .
-                    FILTER(isLiteral(?value) && LANG(?value) = "es")
-                }
-            }
-            """ ;
+    rdfs:comment "Restricción para validar que un recurso tenga el título al menos en español"@es ;
+    rdfs:comment "Restriction to validate that a resource has the title at least in Spanish"@en ;
+    rdfs:label "Restricción de título en español"@es ;
+    rdfs:label "Spanish Title Restriction"@en ;
+    sh:property [
+        sh:path dct:title ;
+        sh:qualifiedValueShape [
+            sh:languageIn ("es") ;
+            sh:nodeKind sh:Literal ;
         ] ;
+        sh:qualifiedMinCount 1 ;
+        sh:message "El título debe tener al menos un valor en español (etiqueta de idioma 'es')."@es ;
+        sh:message "The title must have at least one value in Spanish (language tag 'es')."@en ;
+        sh:severity sh:Violation ;
+    ] ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
     sh:severity sh:Violation .
 
-:Spatial_Shape
+dcatapes:Spatial_Shape
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que un valor espacial sea un IRI válido de vocabularios permitidos, como territorios, países, lugares, continentes, unidades administrativas o GeoNames."@es ;
     rdfs:comment "Restriction to validate that a spatial value is a valid IRI from allowed vocabularies, such as territories, countries, places, continents, administrative units, or GeoNames."@en ;
@@ -863,19 +852,19 @@
     sh:name "Spatial coverage value"@en ;
     sh:name "Valor de cobertura geográfica"@es ;
     sh:or (
-        :TerritoryRestriction
-        :CountryRestriction
-        :PlaceRestriction
-        :ContinentRestriction
-        :AtuRestriction
-        :GeoNamesRestriction
+        dcatapes:TerritoryRestriction
+        dcatapes:CountryRestriction
+        dcatapes:PlaceRestriction
+        dcatapes:ContinentRestriction
+        dcatapes:AtuRestriction
+        dcatapes:GeoNamesRestriction
     );
     sh:severity sh:Violation ;
     foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#dcat-ap-es-vocabularies> ;
     sh:message "El valor de dct:spatial debe ser un IRI de los vocabularios http://datos.gob.es/recurso/sector-publico/territorio, http://publications.europa.eu/resource/authority/country, http://publications.europa.eu/resource/authority/continent, http://publications.europa.eu/resource/authority/place o http://sws.geonames.org."@es ;
     sh:message "The value of dct:spatial must be an IRI from the vocabularies http://datos.gob.es/recurso/sector-publico/territorio, http://publications.europa.eu/resource/authority/country, http://publications.europa.eu/resource/authority/continent, http://publications.europa.eu/resource/authority/place or http://sws.geonames.org."@en .
 
-:HVDCategoryRestriction
+dcatapes:HVDCategoryRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que un valor sea un IRI perteneciente al vocabulario de categorías de distribución de la Unión Europea."@es ;
     rdfs:comment "Restriction to validate that a value is an IRI from the European distribution status vocabulary."@en ;
@@ -890,7 +879,7 @@
     sh:severity sh:Violation .
 
 # Convención 07
-:ELIIdentifierRestriction
+dcatapes:ELIIdentifierRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que un valor sea un IRI que siga el patrón ELI o que sea de tipo eli:LegalResource."@es ;
     rdfs:comment "Restriction to validate that a value is an IRI following the ELI pattern or is of type eli:LegalResource."@en ;
@@ -919,33 +908,31 @@
     sh:message "The value must be a valid ELI identifier or of type eli:LegalResource. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-07"@en .
 
 # Convencion 22
-:TemporalPeriodConvention
+dcatapes:TemporalPeriodConvention
     a sh:NodeShape ;
-    rdfs:comment "Restricción para validar que los períodos temporales sean descritos exclusivamente mediante las propiedades dcat:startDate y dcat:endDate dentro de dct:temporal, cumpliendo con la Convención 22 de DCAT-AP-ES."@es ;
-    rdfs:comment "Restriction to validate that temporal periods are described exclusively using dcat:startDate and dcat:endDate within dct:temporal, complying with DCAT-AP-ES Convention 22."@en ;
+    rdfs:comment "Restricción para validar que los períodos temporales sean descritos mediante al menos una de las propiedades dcat:startDate o dcat:endDate dentro de dct:temporal, cumpliendo con la Convención 22 de DCAT-AP-ES."@es ;
+    rdfs:comment "Restriction to validate that temporal periods are described using at least one of dcat:startDate or dcat:endDate within dct:temporal, complying with DCAT-AP-ES Convention 22."@en ;
     rdfs:label "Restricción para períodos temporales"@es ;
     rdfs:label "Temporal Period Restriction"@en ;
     sh:name "Temporal Period Restriction"@en ;
     sh:name "Restricción para períodos temporales"@es ;
     sh:targetClass dct:PeriodOfTime ;
-    sh:property [
-        sh:path dcat:startDate ;
-        sh:minCount 1 ;
-        sh:nodeKind sh:Literal ;
-        sh:datatype xsd:dateTime ;
-        sh:message "El período temporal debe incluir al menos un dcat:startDate con un valor de tipo xsd:dateTime. Ver: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-22"@es ;
-        sh:message "The temporal period must include at least one dcat:startDate with a value of type xsd:dateTime. See: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-22"@en ;
-        sh:severity sh:Violation ;
-    ] ;
-    sh:property [
-        sh:path dcat:endDate ;
-        sh:minCount 1 ;
-        sh:nodeKind sh:Literal ;
-        sh:datatype xsd:dateTime ;
-        sh:message "El período temporal debe incluir al menos un dcat:endDate con un valor de tipo xsd:dateTime. Ver: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-22"@es ;
-        sh:message "The temporal period must include at least one dcat:endDate with a value of type xsd:dateTime. See: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-22"@en ;
-        sh:severity sh:Violation ;
-    ] ;
+    sh:or (
+        [
+            sh:property [
+                sh:path dcat:startDate ;
+                sh:minCount 1 ;
+                sh:nodeKind sh:Literal ;
+            ]
+        ]
+        [
+            sh:property [
+                sh:path dcat:endDate ;
+                sh:minCount 1 ;
+                sh:nodeKind sh:Literal ;
+            ]
+        ]
+    ) ;
     sh:property [
         sh:path schema:startDate ;
         sh:severity sh:Warning ;
@@ -959,35 +946,54 @@
         sh:message "Replace schema:endDate with dcat:endDate to comply with Convention 22. See: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-22"@en ;
     ] ;
     foaf:page <https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-22> ;
-    sh:message "El período temporal debe ser descrito exclusivamente mediante dcat:startDate y dcat:endDate dentro de dct:temporal. Ver: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-22"@es ;
-    sh:message "The temporal period must be described exclusively using dcat:startDate and dcat:endDate within dct:temporal. See: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-22"@en ;
+    sh:message "El período temporal debe ser descrito mediante al menos una de dcat:startDate o dcat:endDate dentro de dct:temporal. Ver: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-22"@es ;
+    sh:message "The temporal period must be described using at least one of dcat:startDate or dcat:endDate within dct:temporal. See: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-22"@en ;
     sh:severity sh:Violation .
 
-:PeriodOfTimeRestriction
+dcatapes:PeriodOfTimeRestriction
     a sh:NodeShape ;
-    rdfs:comment "Restricción para validar que los nodos de tipo dct:PeriodOfTime tengan sus fechas de inicio y fin correctamente definidas."@es ;
-    rdfs:comment "Restriction to validate that nodes of type dct:PeriodOfTime have their start and end dates properly defined."@en ;
+    rdfs:comment "Restricción para validar que los nodos de tipo dct:PeriodOfTime tengan al menos una fecha de inicio o fin correctamente definida."@es ;
+    rdfs:comment "Restriction to validate that nodes of type dct:PeriodOfTime have at least one start or end date properly defined."@en ;
     rdfs:label "Restricción para periodos de tiempo"@es ;
     rdfs:label "Period of Time Restriction"@en ;
     sh:name "Period of Time"@en ;
     sh:name "Periodo de tiempo"@es ;
+    sh:or (
+        # Al menos debe tener startDate o schema:startDate
+        [
+            sh:property [
+                sh:path [
+                    sh:alternativePath (
+                        dcat:startDate
+                        schema:startDate
+                    )
+                ];
+                sh:nodeKind sh:Literal ;
+                sh:minCount 1 ;
+            ]
+        ]
+        # O debe tener endDate o schema:endDate
+        [
+            sh:property [
+                sh:path [
+                    sh:alternativePath (
+                        dcat:endDate
+                        schema:endDate
+                    )
+                ];
+                sh:nodeKind sh:Literal ;
+                sh:minCount 1 ;
+            ]
+        ]
+    ) ;
     sh:property 
-    # dcat:startDate
     [
         sh:path dcat:startDate ;
         sh:nodeKind sh:Literal ;
         sh:maxCount 1 ;
         sh:severity sh:Violation ;
-        sh:node :DateOrDateTimeDataTypetConvention ;
-        sh:message "El valor de dcat:startDate debe ser un literal de tipo fecha o fecha-hora."@es ;
-        sh:message "The value of dcat:startDate must be a literal of type date or date-time."@en ;
-    ], 
-    [
-        sh:path dcat:startDate ;
-        sh:minCount 1 ;
-        sh:severity sh:Warning ;
-        sh:message "La propiedad dcat:startDate debería estar presente."@es ;
-        sh:message "The property dcat:startDate should be present."@en ;
+        sh:message "Solo puede haber un valor para dcat:startDate."@es ;
+        sh:message "There can only be one value for dcat:startDate."@en ;
     ],
     [
         sh:path schema:startDate ;
@@ -995,29 +1001,20 @@
         sh:message "Reemplace la propiedad schema:startDate por dcat:startDate."@es ;
         sh:message "Replace property schema:startDate with dcat:startDate."@en ;
     ],
-    # dcat:endDate
     [
         sh:path dcat:endDate ;
         sh:nodeKind sh:Literal ;
         sh:maxCount 1 ;
         sh:severity sh:Violation ;
-        sh:node :DateOrDateTimeDataTypetConvention ;
-        sh:message "El valor de dcat:endDate debe ser un literal de tipo fecha o fecha-hora."@es ;
-        sh:message "The value of dcat:endDate must be a literal of type date or date-time."@en ;
+        sh:message "Solo puede haber un valor para dcat:endDate."@es ;
+        sh:message "There can only be one value for dcat:endDate."@en ;
     ],
-    [
-        sh:path dcat:endDate ;
-        sh:minCount 1 ;
-        sh:severity sh:Warning ;
-        sh:message "La propiedad dcat:endDate debería estar presente."@es ;
-        sh:message "The property dcat:endDate should be present."@en ;
-    ], 
     [
         sh:path schema:endDate ;
         sh:severity sh:Warning ;
         sh:message "Reemplace la propiedad schema:endDate por dcat:endDate."@es ;
         sh:message "Replace property schema:endDate with dcat:endDate."@en ;
-    ], 
+    ],
     # time:hasBeginning
     [
         sh:path time:hasBeginning ;

--- a/shacl/1.0.0/shacl_dataservice_shape.ttl
+++ b/shacl/1.0.0/shacl_dataservice_shape.ttl
@@ -385,14 +385,6 @@ dcatapes:DataService_Shape
         sh:path dcat:keyword ;
         sh:node dcatapes:NonEmptyLiteralConvention ; 
         sh:severity sh:Violation ;
-    ],
-    [
-        sh:path dcat:keyword ;
-        sh:uniqueLang true;
-        sh:severity sh:Violation ;
-        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
-        sh:message "Más de un valor comparten la misma etiqueta de idioma. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@es ;
-        sh:message "More than one value shares the same language tag. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@en ;
     ];
     sh:targetClass dcat:DataService .
 

--- a/shacl/1.0.0/shacl_dataservice_shape.ttl
+++ b/shacl/1.0.0/shacl_dataservice_shape.ttl
@@ -1,5 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix : <http://datos.gob.es/dcat-ap-es#> .
 @prefix cc: <http://creativecommons.org/ns#> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dct: <http://purl.org/dc/terms/> .
@@ -44,7 +43,7 @@
 #--------------------------
 # dcat:DataService restrictions
 #--------------------------
-:DataService_Shape
+dcatapes:DataService_Shape
     a sh:NodeShape ;
     sh:name "Servicio de Datos"@en ;
     sh:name "Data Service"@en ;
@@ -65,18 +64,21 @@
     ], 
     [
         sh:path dct:title ;
-        sh:node :LiteralMultilingualConvention ; 
+        sh:node dcatapes:LiteralMultilingualConvention ; 
         sh:severity sh:Violation ;
     ],
     [
         sh:path dct:title ;
-        sh:node :NonEmptyLiteralConvention ; 
+        sh:node dcatapes:NonEmptyLiteralConvention ; 
         sh:severity sh:Violation ;
     ],
     [
         sh:path dct:title ;
-        sh:node :UniqueLangLiteralRestriction ;
+        sh:uniqueLang true;
         sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
+        sh:message "Más de un valor comparten la misma etiqueta de idioma. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@es ;
+        sh:message "More than one value shares the same language tag. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@en ;
     ],
 
     # dcat:endpointURL
@@ -108,24 +110,24 @@
     ],
     [
         sh:path dcatap:hvdCategory;
-        sh:node :HVDCategoryRestriction ;
+        sh:node dcatapes:HVDCategoryRestriction ;
         sh:severity sh:Violation ;
     ],
 
     # dcat:contactPoint
     [
         sh:path dcat:contactPoint ;
-        sh:not :DIR3OrganismRestriction ;
+        sh:not dcatapes:DIR3OrganismRestriction ;
         sh:severity sh:Violation
     ],
     [
         sh:path dcat:contactPoint ;
-        sh:node :VcardKindMinimalConvention ;
-        sh:severity sh:Violation
+        sh:node dcatapes:VcardKindMinimalConvention ;
+        sh:severity sh:Warning ;
     ],
     [
         sh:path dcat:contactPoint ;
-        sh:node :VcardKindRestriction2 ;
+        sh:node dcatapes:VcardKindRestriction2 ;
         sh:severity sh:Violation
     ],
     [
@@ -168,7 +170,7 @@
     [
 		sh:path dcat:theme ;
 	    sh:qualifiedValueShape [
-			sh:node :PublicSectorRestriction ;
+			sh:node dcatapes:PublicSectorRestriction ;
 		];	
         sh:qualifiedMinCount 1;
         sh:severity sh:Violation
@@ -178,13 +180,13 @@
         sh:nodeKind sh:IRI ;
         sh:or(
             [   
-                sh:node :PublicSectorRestriction ;
+                sh:node dcatapes:PublicSectorRestriction ;
             ]
             [   
-                sh:node :EuropeanDataThemeRestriction ;
+                sh:node dcatapes:EuropeanDataThemeRestriction ;
             ]
             [
-                sh:node :InspireDataThemeRestriction ;
+                sh:node dcatapes:InspireDataThemeRestriction ;
             ]
         );
         sh:severity sh:Violation
@@ -209,7 +211,7 @@
     ],
     [
         sh:path dct:publisher ;
-        sh:node :DIR3OrganismRestriction;
+        sh:node dcatapes:DIR3OrganismRestriction;
         sh:or(
             [
                 sh:nodeKind sh:IRI; 
@@ -217,8 +219,8 @@
             ]
             [
                 sh:nodeKind sh:BlankNodeOrIRI;
-                sh:node :Agent_Shape;
-                sh:node :PublisherAgentRestriction;
+                sh:node dcatapes:Agent_Shape;
+                sh:node dcatapes:PublisherAgentRestriction;
             ]
         );
         sh:severity sh:Violation ;
@@ -235,7 +237,7 @@
             ]
             [
                 sh:nodeKind sh:BlankNodeOrIRI;
-                sh:node :Agent_ShapeRecommended
+                sh:node dcatapes:Agent_ShapeRecommended
             ]
         );
         sh:severity sh:Warning ;
@@ -299,7 +301,7 @@
     ], 
     [
         sh:path dcatap:applicableLegislation ;
-        sh:node :ELIIdentifierRestriction ;
+        sh:node dcatapes:ELIIdentifierRestriction ;
         sh:severity sh:Violation ;
     ],
 
@@ -314,18 +316,21 @@
     ],
     [
         sh:path dct:description ;
-        sh:node :LiteralMultilingualConvention ; 
+        sh:node dcatapes:LiteralMultilingualConvention ; 
         sh:severity sh:Violation ;
     ],
     [
         sh:path dct:description ;
-        sh:node :NonEmptyLiteralConvention ; 
+        sh:node dcatapes:NonEmptyLiteralConvention ; 
         sh:severity sh:Violation ;
     ],
     [
         sh:path dct:description ;
-        sh:node :UniqueLangLiteralRestriction ;
+        sh:uniqueLang true;
         sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
+        sh:message "Más de un valor comparten la misma etiqueta de idioma. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@es ;
+        sh:message "More than one value shares the same language tag. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@en ;
     ],
 
     # dct:accessRights
@@ -339,7 +344,7 @@
     ],
     [
         sh:path dct:accessRights ;
-		sh:node :AccessRightRestriction ;
+		sh:node dcatapes:AccessRightRestriction ;
         sh:severity sh:Violation
 	],
 
@@ -355,8 +360,8 @@
     [
         sh:path dct:license ;
         sh:or (
-            [ sh:node :LicenceDocumentRestriction ;]
-            [ sh:node :LicenceRestriction ;]
+            [ sh:node dcatapes:LicenceDocumentRestriction ;]
+            [ sh:node dcatapes:LicenceRestriction ;]
             [ sh:nodeKind sh:IRI ;]
         );
         sh:severity sh:Violation ;
@@ -373,23 +378,26 @@
     ],
     [
         sh:path dcat:keyword ;
-        sh:node :LiteralMultilingualConvention ; 
+        sh:node dcatapes:LiteralMultilingualConvention ; 
         sh:severity sh:Violation ;
     ],
     [
         sh:path dcat:keyword ;
-        sh:node :NonEmptyLiteralConvention ; 
+        sh:node dcatapes:NonEmptyLiteralConvention ; 
         sh:severity sh:Violation ;
     ],
     [
         sh:path dcat:keyword ;
-        sh:node :UniqueLangLiteralRestriction ;
+        sh:uniqueLang true;
         sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
+        sh:message "Más de un valor comparten la misma etiqueta de idioma. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@es ;
+        sh:message "More than one value shares the same language tag. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@en ;
     ];
     sh:targetClass dcat:DataService .
 
 # Convencion 02
-:DataServiceSPALanguageRestriction
+dcatapes:DataServiceSPALanguageRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que un servicio de datos cumpla con las convenciones de idioma y contenido en español, incluyendo título, descripción y otros elementos clave."@es ;
     rdfs:comment "Restriction to validate that a data service complies with Spanish language and content conventions, including title, description, and other key elements."@en ;
@@ -397,9 +405,9 @@
     rdfs:label "Data service restriction: Spanish language and content"@en ;
     sh:name "Data service Spanish Language and Content Restriction"@en ;
     sh:name "Restricción de servicio de datos: idioma y contenido en español"@es ;
-    sh:node :SpanishLanguageRestriction ;
-    sh:node :SpanishTitleRestriction ;
-    sh:node :SpanishDescriptionRestriction ;
+    sh:node dcatapes:SpanishLanguageRestriction ;
+    sh:node dcatapes:SpanishTitleRestriction ;
+    sh:node dcatapes:SpanishDescriptionRestriction ;
     sh:severity sh:Violation ;
     foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
     sh:targetClass dcat:DataService .

--- a/shacl/1.0.0/shacl_dataset_shape.ttl
+++ b/shacl/1.0.0/shacl_dataset_shape.ttl
@@ -242,14 +242,6 @@ dcatapes:Dataset_Shape
         sh:node dcatapes:NonEmptyLiteralConvention ; 
         sh:severity sh:Violation ;
     ],
-    [
-        sh:path dcat:keyword ;
-        sh:uniqueLang true;
-        sh:severity sh:Violation ;
-        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
-        sh:message "Más de un valor comparten la misma etiqueta de idioma. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@es ;
-        sh:message "More than one value shares the same language tag. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@en ;
-    ],
 
     # dcat:contactPoint
     [

--- a/shacl/1.0.0/shacl_dataset_shape.ttl
+++ b/shacl/1.0.0/shacl_dataset_shape.ttl
@@ -1,5 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix : <http://datos.gob.es/dcat-ap-es#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix cc: <http://creativecommons.org/ns#> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
@@ -52,7 +51,7 @@
 #--------------------------
 # dcat:Dataset restrictions
 #--------------------------
-:Dataset_Shape
+dcatapes:Dataset_Shape
     a sh:NodeShape ;
     sh:name "Conjunto de datos"@en ;
     sh:name "Dataset"@en ;
@@ -73,18 +72,21 @@
     ], 
     [
         sh:path dct:title ;
-        sh:node :LiteralMultilingualConvention ; 
+        sh:node dcatapes:LiteralMultilingualConvention ; 
         sh:severity sh:Violation ;
     ],
     [
         sh:path dct:title ;
-        sh:node :NonEmptyLiteralConvention ; 
+        sh:node dcatapes:NonEmptyLiteralConvention ; 
         sh:severity sh:Violation ;
     ],
     [
         sh:path dct:title ;
-        sh:node :UniqueLangLiteralRestriction ;
+        sh:uniqueLang true;
         sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
+        sh:message "Más de un valor comparten la misma etiqueta de idioma. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@es ;
+        sh:message "More than one value shares the same language tag. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@en ;
     ],
 
     # dct:description
@@ -106,18 +108,21 @@
     ], 
     [
         sh:path dct:description ;
-        sh:node :LiteralMultilingualConvention ;
+        sh:node dcatapes:LiteralMultilingualConvention ;
         sh:severity sh:Violation ;
     ],
     [
         sh:path dct:description ;
-        sh:node :NonEmptyLiteralConvention ;
+        sh:node dcatapes:NonEmptyLiteralConvention ;
         sh:severity sh:Violation ; 
     ],
     [
         sh:path dct:description ;
-        sh:node :UniqueLangLiteralRestriction ;
+        sh:uniqueLang true;
         sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
+        sh:message "Más de un valor comparten la misma etiqueta de idioma. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@es ;
+        sh:message "More than one value shares the same language tag. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@en ;
     ],
 
     # dct:publisher
@@ -139,7 +144,7 @@
     ],
     [
         sh:path dct:publisher ;
-        sh:node :DIR3OrganismRestriction;
+        sh:node dcatapes:DIR3OrganismRestriction;
         sh:or(
             [
                 sh:nodeKind sh:IRI; 
@@ -147,8 +152,8 @@
             ]
             [
                 sh:nodeKind sh:BlankNodeOrIRI;
-                sh:node :Agent_Shape;
-                sh:node :PublisherAgentRestriction;
+                sh:node dcatapes:Agent_Shape;
+                sh:node dcatapes:PublisherAgentRestriction;
             ]
         );
         sh:severity sh:Violation ;
@@ -165,7 +170,7 @@
             ]
             [
                 sh:nodeKind sh:BlankNodeOrIRI;
-                sh:node :Agent_ShapeRecommended
+                sh:node dcatapes:Agent_ShapeRecommended
             ]
         );
         sh:severity sh:Warning ;
@@ -186,7 +191,7 @@
     [
 		sh:path dcat:theme ;
 	    sh:qualifiedValueShape [
-			sh:node :PublicSectorRestriction ;
+			sh:node dcatapes:PublicSectorRestriction ;
 		];	
         sh:qualifiedMinCount 1;
         sh:severity sh:Violation
@@ -196,13 +201,13 @@
         sh:nodeKind sh:IRI ;
         sh:or(
             [   
-                sh:node :PublicSectorRestriction ;
+                sh:node dcatapes:PublicSectorRestriction ;
             ]
             [   
-                sh:node :EuropeanDataThemeRestriction ;
+                sh:node dcatapes:EuropeanDataThemeRestriction ;
             ]
             [
-                sh:node :InspireDataThemeRestriction ;
+                sh:node dcatapes:InspireDataThemeRestriction ;
             ]
         );
         sh:severity sh:Violation
@@ -211,11 +216,11 @@
     # dcat:Distribution
     [
         sh:path dcat:distribution ;
-        sh:nodeKind sh:Literal ;
+        sh:class dcat:Distribution ;
         sh:severity sh:Violation ;
         foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dcat_distribution> ;
-        sh:message "El valor de dcat:distribution debe ser un Literal."@es ;
-        sh:message "The value of dcat:distribution must be a Literal."@en ;
+        sh:message "El valor de dcat:distribution debe ser un dcat:Distribution."@es ;
+        sh:message "The value of dcat:distribution must be a dcat:Distribution."@en ;
     ], 
 
     # dcat:keyword
@@ -229,34 +234,37 @@
     ],
     [
         sh:path dcat:keyword ;
-        sh:node :LiteralMultilingualConvention ; 
+        sh:node dcatapes:LiteralMultilingualConvention ; 
         sh:severity sh:Violation ;
     ],
     [
         sh:path dcat:keyword ;
-        sh:node :NonEmptyLiteralConvention ; 
+        sh:node dcatapes:NonEmptyLiteralConvention ; 
         sh:severity sh:Violation ;
     ],
     [
         sh:path dcat:keyword ;
-        sh:node :UniqueLangLiteralRestriction ;
+        sh:uniqueLang true;
         sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
+        sh:message "Más de un valor comparten la misma etiqueta de idioma. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@es ;
+        sh:message "More than one value shares the same language tag. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@en ;
     ],
 
     # dcat:contactPoint
     [
         sh:path dcat:contactPoint ;
-        sh:not :DIR3OrganismRestriction ;
+        sh:not dcatapes:DIR3OrganismRestriction ;
         sh:severity sh:Violation
     ],
     [
         sh:path dcat:contactPoint ;
-        sh:node :VcardKindMinimalConvention ;
-        sh:severity sh:Violation
+        sh:node dcatapes:VcardKindMinimalConvention ;
+        sh:severity sh:Warning ;
     ],
     [
         sh:path dcat:contactPoint ;
-        sh:node :VcardKindRestriction2 ;
+        sh:node dcatapes:VcardKindRestriction2 ;
         sh:severity sh:Violation
     ],
     [
@@ -278,8 +286,8 @@
         sh:message "The dataset should contain at least one dct:temporal."@en ;
     ], 
     [
-        sh:path dcatap:applicableLegislation ;
-        sh:node :TemporalPeriodConvention ;
+        sh:path dct:temporal ;
+        sh:node dcatapes:TemporalPeriodConvention ;
         sh:severity sh:Violation ;
     ],
 
@@ -299,10 +307,10 @@
             [ 
                 sh:class dct:Location ;
                 # WKT restriction
-                sh:node :SpatialGeometryConvention ; 
+                sh:node dcatapes:SpatialGeometryConvention ; 
             ]
             [ 
-                sh:node :Spatial_Shape ;
+                sh:node dcatapes:Spatial_Shape ;
                 sh:nodeKind sh:IRI ;
                 sh:severity sh:Violation;
             ]
@@ -317,12 +325,12 @@
     [
         sh:path dct:identifier ;
         sh:nodeKind sh:Literal ;
-        sh:node :NonLiteralMultilingualConvention ;
+        sh:node dcatapes:NonLiteralMultilingualConvention ;
         sh:severity sh:Violation
     ],
     [
         sh:path dct:identifier ;
-        sh:node :NonEmptyLiteralConvention;
+        sh:node dcatapes:NonEmptyLiteralConvention;
         sh:severity sh:Violation
     ],
 
@@ -346,8 +354,8 @@
             ]
             [
                 sh:nodeKind sh:BlankNodeOrIRI;
-                sh:node :Agent_Shape;
-                sh:node :CreatorAgentRestriction;
+                sh:node dcatapes:Agent_Shape;
+                sh:node dcatapes:CreatorAgentRestriction;
             ]
         );
         sh:severity sh:Violation ;
@@ -361,7 +369,7 @@
             ]
             [
                 sh:nodeKind sh:BlankNodeOrIRI;
-                sh:node :Agent_ShapeRecommended
+                sh:node dcatapes:Agent_ShapeRecommended
             ]
         );
         sh:severity sh:Warning ;
@@ -413,7 +421,7 @@
         sh:path dct:issued ;
         sh:maxCount 1 ;
         sh:nodeKind sh:Literal ;
-        sh:node :DateOrDateTimeDataTypetConvention ;
+        sh:node dcatapes:DateOrDateTimeDataTypetConvention ;
         sh:severity sh:Violation ;
     ],
 
@@ -422,7 +430,7 @@
         sh:path dct:modified ;
         sh:maxCount 1 ;
         sh:nodeKind sh:Literal ;
-        sh:node :DateOrDateTimeDataTypetConvention ;
+        sh:node dcatapes:DateOrDateTimeDataTypetConvention ;
         sh:severity sh:Violation ;
     ], 
 
@@ -433,10 +441,10 @@
         sh:nodeKind sh:IRI ;
         sh:or(
             [
-                sh:node :DatasetTypeRestriction
+                sh:node dcatapes:DatasetTypeRestriction
             ]
             [
-                sh:node :INSPIREDatasetTypeRestriction
+                sh:node dcatapes:INSPIREDatasetTypeRestriction
             ]
         );
         sh:severity sh:Warning ;
@@ -448,7 +456,7 @@
     # dct:language
     [
         sh:path dct:language ;
-        sh:node :LanguageRestriction ;
+        sh:node dcatapes:LanguageRestriction ;
         sh:severity sh:Violation ;
     ], 
 
@@ -459,7 +467,7 @@
             [ 
                 # IRI from european vocabulary
                 sh:nodeKind sh:IRI ;
-                sh:node :FrequencyRestriction ;
+                sh:node dcatapes:FrequencyRestriction ;
             ]
             [ 
                 # Frequency node
@@ -469,7 +477,7 @@
                 # Literal of xsd:duration type (NTI legacy)
                 sh:nodeKind sh:Literal ;
                 sh:datatype xsd:duration ;
-                sh:node :DurationRestriction;
+                sh:node dcatapes:DurationRestriction;
             ]
         );
         sh:severity sh:Violation;
@@ -482,12 +490,12 @@
     [
         sh:path dcat:version ;
         sh:nodeKind sh:Literal ;
-        sh:node :NonLiteralMultilingualConvention ;
+        sh:node dcatapes:NonLiteralMultilingualConvention ;
         sh:severity sh:Violation
     ],
     [
         sh:path dcat:version ;
-        sh:node :NonEmptyLiteralConvention ;
+        sh:node dcatapes:NonEmptyLiteralConvention ;
         sh:severity sh:Violation
     ],
     [
@@ -510,18 +518,21 @@
     ], 
     [
         sh:path adms:versionNotes ;
-        sh:node :LiteralMultilingualConvention ; 
+        sh:node dcatapes:LiteralMultilingualConvention ; 
         sh:severity sh:Violation ;
     ],
     [
         sh:path adms:versionNotes ;
-        sh:node :NonEmptyLiteralConvention ; 
+        sh:node dcatapes:NonEmptyLiteralConvention ; 
         sh:severity sh:Violation ;
     ],
     [
         sh:path adms:versionNotes ;
-        sh:node :UniqueLangLiteralRestriction ;
+        sh:uniqueLang true;
         sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
+        sh:message "Más de un valor comparten la misma etiqueta de idioma. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@es ;
+        sh:message "More than one value shares the same language tag. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@en ;
     ],
 
     # dcat:hasVersion
@@ -590,7 +601,7 @@
         sh:path dcat:temporalResolution ;
         sh:nodeKind sh:Literal ;
         sh:datatype xsd:duration ;
-        sh:node :DurationRestriction;
+        sh:node dcatapes:DurationRestriction;
         sh:severity sh:Violation ;
     ],
 
@@ -679,13 +690,13 @@
     [
         sh:path dct:accessRights ;
         sh:nodeKind sh:IRI ;
-		sh:node :AccessRightRestriction ;
+		sh:node dcatapes:AccessRightRestriction ;
         sh:severity sh:Violation ;
 	];
     sh:targetClass dcat:Dataset .
 
 # Convencion 02
-:DatasetSPALanguageConvention
+dcatapes:DatasetSPALanguageConvention
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que un conjunto de datos cumpla con las convenciones de idioma y contenido en español, incluyendo título, descripción y otros elementos clave."@es ;
     rdfs:comment "Restriction to validate that a dataset complies with Spanish language and content conventions, including title, description, and other key elements."@en ;
@@ -693,15 +704,15 @@
     rdfs:label "Dataset restriction: Spanish language and content"@en ;
     sh:name "Dataset Spanish Language and Content Restriction"@en ;
     sh:name "Restricción de conjunto de datos: idioma y contenido en español"@es ;
-    sh:node :SpanishLanguageRestriction ;
-    sh:node :SpanishTitleRestriction ;
-    sh:node :SpanishDescriptionRestriction ;
+    sh:node dcatapes:SpanishLanguageRestriction ;
+    sh:node dcatapes:SpanishTitleRestriction ;
+    sh:node dcatapes:SpanishDescriptionRestriction ;
     sh:severity sh:Violation ;
     foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
     sh:targetClass dcat:Dataset .
 
 # Convencion 23
-:DistributionMandatoryConvention
+dcatapes:DistributionMandatoryConvention
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que los conjuntos de datos contengan al menos una distribución (dcat:distribution), cumpliendo con la Convención 23 de DCAT-AP-ES."@es ;
     rdfs:comment "Restriction to validate that datasets include at least one distribution (dcat:distribution), complying with DCAT-AP-ES Convention 23."@en ;
@@ -725,7 +736,7 @@
 # Other shapes restrictions
 #---------------------------
 
-:Activity_Shape
+dcatapes:Activity_Shape
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que los nodos de tipo prov:Activity tengan propiedades temporales correctamente definidas."@es ;
     rdfs:comment "Restriction to validate that nodes of type prov:Activity have properly defined temporal properties."@en ;
@@ -745,7 +756,7 @@
     [
         sh:path prov:startedAtTime ;
         sh:nodeKind sh:Literal ;
-        sh:node :DateOrDateTimeDataTypetConvention ;
+        sh:node dcatapes:DateOrDateTimeDataTypetConvention ;
         sh:severity sh:Violation ;
         sh:message "El valor de prov:startedAtTime debe ser un literal de tipo fecha o fecha-hora."@es ;
         sh:message "The value of prov:startedAtTime must be a literal of type date or date-time."@en ;
@@ -761,14 +772,14 @@
     [
         sh:path prov:endedAtTime ;
         sh:nodeKind sh:Literal ;
-        sh:node :DateOrDateTimeDataTypetConvention ;
+        sh:node dcatapes:DateOrDateTimeDataTypetConvention ;
         sh:severity sh:Violation ;
         sh:message "El valor de prov:endedAtTime debe ser un literal de tipo fecha o fecha-hora."@es ;
         sh:message "The value of prov:endedAtTime must be a literal of type date or date-time."@en ;
     ] ;
     sh:targetClass prov:Activity .
 
-:Attribution_Shape
+dcatapes:Attribution_Shape
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que los nodos de tipo prov:Attribution tengan un agente y, opcionalmente, un rol definido."@es ;
     rdfs:comment "Restriction to validate that nodes of type prov:Attribution have an agent and, optionally, a defined role."@en ;
@@ -809,7 +820,7 @@
     ];
     sh:targetClass prov:Attribution .
 
-:DurationDescription_Shape
+dcatapes:DurationDescription_Shape
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que los nodos de tipo time:DurationDescription contengan exactamente una propiedad de medida temporal."@es ;
     rdfs:comment "Restriction to validate that time:DurationDescription nodes contain exactly one temporal measurement property."@en ;
@@ -819,20 +830,20 @@
     sh:name "Time Duration Description"@en ;
     sh:targetClass time:DurationDescription ;
     sh:xone (
-        :TimeYearsRestriction
-        :TimeMonthsRestriction
-        :TimeWeeksRestriction
-        :TimeDaysRestriction
-        :TimeHoursRestriction
-        :TimeMinutesRestriction
-        :TimeSecondsRestriction
+        dcatapes:TimeYearsRestriction
+        dcatapes:TimeMonthsRestriction
+        dcatapes:TimeWeeksRestriction
+        dcatapes:TimeDaysRestriction
+        dcatapes:TimeHoursRestriction
+        dcatapes:TimeMinutesRestriction
+        dcatapes:TimeSecondsRestriction
     );
     sh:severity sh:Violation ;
     foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-time_durationdescription> ;
     sh:message "Un time:DurationDescription debe tener exactamente una de las propiedades: time:years, time:months, time:weeks, time:days, time:hours, time:minutes, o time:seconds."@es ;
     sh:message "A time:DurationDescription must have exactly one of the properties: time:years, time:months, time:weeks, time:days, time:hours, time:minutes, or time:seconds."@en .
 
-:Frequency_Shape
+dcatapes:Frequency_Shape
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que los nodos de tipo dct:Frequency contengan exactamente un valor de duración correctamente definido."@es ;
     rdfs:comment "Restriction to validate that nodes of type dct:Frequency contain exactly one properly defined duration value."@en ;
@@ -852,7 +863,7 @@
                 # Literal Duration
                 sh:nodeKind sh:Literal ;
                 sh:datatype xsd:duration ;
-                sh:node :DurationRestriction ;
+                sh:node dcatapes:DurationRestriction ;
             ]
         ) ;
         sh:severity sh:Violation ;
@@ -878,7 +889,7 @@
     sh:message "El valor de dct:frequency debe ser un dct:Frequency."@es ;
     sh:message "The value of dct:frequency must be a dct:Frequency."@en .
 
-:ADMSIdentifier_Shape
+dcatapes:ADMSIdentifier_Shape
     # https://www.w3.org/TR/vocab-adms/#identifier
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que los identificadores ADMS contengan exactamente un valor de notación no vacío."@es ;
@@ -893,14 +904,14 @@
     [
         sh:path skos:notation ;
         sh:nodeKind sh:Literal ;
-        sh:node :NonLiteralMultilingualConvention ;
+        sh:node dcatapes:NonLiteralMultilingualConvention ;
         sh:severity sh:Violation ;
         sh:message "El valor de skos:notation debe ser un literal sin etiqueta de idioma."@es ;
         sh:message "The value of skos:notation must be a literal without a language tag."@en ;
     ],
     [
         sh:path skos:notation ;
-        sh:node :NonEmptyLiteralConvention;
+        sh:node dcatapes:NonEmptyLiteralConvention;
         sh:severity sh:Violation ;
         sh:message "El valor de skos:notation no puede estar vacío."@es ;
         sh:message "The value of skos:notation cannot be empty."@en ;
@@ -925,7 +936,7 @@
     sh:message "The value of adms:identifier must be a adms:Identifier."@en .
     
 
-:Relationship_Shape
+dcatapes:Relationship_Shape
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que los nodos de tipo dcat:Relationship contengan las propiedades obligatorias correctamente definidas."@es ;
     rdfs:comment "Restriction to validate that nodes of type dcat:Relationship contain properly defined mandatory properties."@en ;
@@ -970,71 +981,71 @@
     sh:message "El valor de dcat:qualifiedRelation debe ser un dcat:Relationship."@es ;
     sh:message "The value of dcat:qualifiedRelation must be a dcat:Relationship."@en .
 
-:TimeDaysRestriction
+dcatapes:TimeDaysRestriction
     a sh:NodeShape ;
     sh:property [
         sh:path time:days ;
-        sh:node :NonNegativeIntegerRestriction ;
+        sh:node dcatapes:NonNegativeIntegerRestriction ;
         sh:maxCount 1 ;
         sh:minCount 1;
     ] .
 
-:TimeHoursRestriction
+dcatapes:TimeHoursRestriction
     a sh:NodeShape ;
     sh:property [
         sh:path time:hours ;
-        sh:node :NonNegativeIntegerRestriction ;
+        sh:node dcatapes:NonNegativeIntegerRestriction ;
         sh:maxCount 1 ;
         sh:minCount 1;
     ] .
 
-:TimeMinutesRestriction
+dcatapes:TimeMinutesRestriction
     a sh:NodeShape ;
     sh:property [
         sh:path time:minutes ;
-        sh:node :NonNegativeIntegerRestriction ;
+        sh:node dcatapes:NonNegativeIntegerRestriction ;
         sh:maxCount 1 ;
         sh:minCount 1;
     ] .
 
-:TimeMonthsRestriction
+dcatapes:TimeMonthsRestriction
     a sh:NodeShape ;
     sh:property [
         sh:path time:months ;
-        sh:node :NonNegativeIntegerRestriction ;
+        sh:node dcatapes:NonNegativeIntegerRestriction ;
         sh:maxCount 1 ;
         sh:minCount 1;
     ] .
 
-:TimeSecondsRestriction
+dcatapes:TimeSecondsRestriction
     a sh:NodeShape ;
     sh:property [
         sh:path time:seconds ;
-        sh:node :NonNegativeIntegerRestriction ;
+        sh:node dcatapes:NonNegativeIntegerRestriction ;
         sh:maxCount 1 ;
         sh:minCount 1;
     ] .
 
-:TimeWeeksRestriction
+dcatapes:TimeWeeksRestriction
     a sh:NodeShape ;
     sh:property [
         sh:path time:weeks ;
-        sh:node :NonNegativeIntegerRestriction ;
+        sh:node dcatapes:NonNegativeIntegerRestriction ;
         sh:maxCount 1 ;
         sh:minCount 1;
     ] .
 
-:TimeYearsRestriction
+dcatapes:TimeYearsRestriction
     a sh:NodeShape ;
     sh:property [
         sh:path time:years ;
-        #sh:node :NonNegativeIntegerRestriction ;
+        #sh:node dcatapes:NonNegativeIntegerRestriction ;
         sh:maxCount 1 ;
         sh:minCount 1;
     ] .
 
 # Convencion 17
-:SpatialGeometryConvention
+dcatapes:SpatialGeometryConvention
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que las referencias espaciales geométricas usen WKT (Well-Known Text) según GeoSPARQL, cumpliendo con la Convención 17 de DCAT-AP-ES."@es ;
     rdfs:comment "Restriction to validate that spatial geometric references use WKT (Well-Known Text) according to GeoSPARQL, complying with DCAT-AP-ES Convention 17."@en ;
@@ -1073,7 +1084,7 @@
 #--------------------------
 # Vocabulary restrictions
 #--------------------------
-:FrequencyRestriction
+dcatapes:FrequencyRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que los valores de dct:accrualPeriodicity sean IRIs válidos del vocabulario europeo de frecuencias."@es ;
     rdfs:comment "Restriction to validate that dct:accrualPeriodicity values are valid IRIs from the European frequency vocabulary."@en ;
@@ -1088,7 +1099,7 @@
     sh:message "El valor debe ser un IRI del vocabulario europeo de frecuencias http://publications.europa.eu/resource/authority/frequency."@es ;
     sh:message "The value must be an IRI from the European frequency vocabulary http://publications.europa.eu/resource/authority/frequency."@en .
 
-:DatasetTypeRestriction
+dcatapes:DatasetTypeRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que los valores de dct:type sean IRIs válidos del vocabulario europeo de tipos de conjuntos de datos."@es ;
     rdfs:comment "Restriction to validate that dct:type values are valid IRIs from the European dataset type vocabulary."@en ;
@@ -1103,7 +1114,7 @@
     sh:message "El valor debe ser un IRI del vocabulario europeo de tipos de conjunto de datos http://publications.europa.eu/resource/authority/dataset-type."@es ;
     sh:message "The value must be an IRI from the European dataset type vocabulary http://publications.europa.eu/resource/authority/dataset-type."@en .
 
-:INSPIREDatasetTypeRestriction
+dcatapes:INSPIREDatasetTypeRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que los valores de dct:type para conjuntos de datos INSPIRE utilicen el IRI oficial especificado."@es ;
     rdfs:comment "Restriction to validate that dct:type values for INSPIRE datasets use the official specified IRI."@en ;

--- a/shacl/1.0.0/shacl_dataset_shape.ttl
+++ b/shacl/1.0.0/shacl_dataset_shape.ttl
@@ -1031,7 +1031,7 @@ dcatapes:TimeYearsRestriction
     a sh:NodeShape ;
     sh:property [
         sh:path time:years ;
-        #sh:node dcatapes:NonNegativeIntegerRestriction ;
+        sh:node dcatapes:NonNegativeIntegerRestriction ;
         sh:maxCount 1 ;
         sh:minCount 1;
     ] .

--- a/shacl/1.0.0/shacl_distribution_shape.ttl
+++ b/shacl/1.0.0/shacl_distribution_shape.ttl
@@ -1,5 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix : <https://datosgobes.github.io/DCAT-AP-ES/> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix cc: <http://creativecommons.org/ns#> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
@@ -46,7 +45,7 @@
 #--------------------------
 # dcat:Distribution restrictions
 #--------------------------
-:Distribution_Shape
+dcatapes:Distribution_Shape
     a sh:NodeShape ;
     sh:name "Distribución"@en ;
     sh:name "Distribution"@en ;
@@ -93,7 +92,7 @@
     ], 
     [
         sh:path dcatap:applicableLegislation ;
-        sh:node :ELIIdentifierRestriction ;
+        sh:node dcatapes:ELIIdentifierRestriction ;
         sh:severity sh:Violation ;
     ],
 
@@ -116,18 +115,21 @@
     ], 
     [
         sh:path dct:description ;
-        sh:node :LiteralMultilingualConvention ;
+        sh:node dcatapes:LiteralMultilingualConvention ;
         sh:severity sh:Violation ;
     ],
     [
         sh:path dct:description ;
-        sh:node :NonEmptyLiteralConvention ;
+        sh:node dcatapes:NonEmptyLiteralConvention ;
         sh:severity sh:Violation ; 
     ],
     [
         sh:path dct:description ;
-        sh:node :UniqueLangLiteralRestriction ;
+        sh:uniqueLang true;
         sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
+        sh:message "Más de un valor comparten la misma etiqueta de idioma. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@es ;
+        sh:message "More than one value shares the same language tag. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@en ;
     ],
 
     # dcatap:availability
@@ -157,7 +159,7 @@
     ],  
     [
         sh:path dcatap:availability ;
-        sh:node :AvailabilityRestriction ;
+        sh:node dcatapes:AvailabilityRestriction ;
         sh:severity sh:Violation ;
     ],
 
@@ -182,7 +184,7 @@
         sh:path dct:format ;
         sh:or (
             [ 
-                sh:node :FileTypeRestriction ;
+                sh:node dcatapes:FileTypeRestriction ;
                 sh:nodeKind sh:IRI ;
             ]
             #TODO: Review DCAT-AP-ES model
@@ -219,8 +221,8 @@
     [
         sh:path dct:license ;
         sh:or (
-            [ sh:node :LicenceDocumentRestriction ;]
-            [ sh:node :LicenceRestriction ;]
+            [ sh:node dcatapes:LicenceDocumentRestriction ;]
+            [ sh:node dcatapes:LicenceRestriction ;]
             [ sh:nodeKind sh:IRI ;]
         );
         sh:severity sh:Violation ;
@@ -255,18 +257,21 @@
     ], 
     [
         sh:path dct:title ;
-        sh:node :LiteralMultilingualConvention ;
+        sh:node dcatapes:LiteralMultilingualConvention ;
         sh:severity sh:Violation ;
     ],
     [
         sh:path dct:title ;
-        sh:node :NonEmptyLiteralConvention ;
+        sh:node dcatapes:NonEmptyLiteralConvention ;
         sh:severity sh:Violation ;
     ],
     [
         sh:path dct:title ;
-        sh:node :UniqueLangLiteralRestriction ;
+        sh:uniqueLang true;
         sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
+        sh:message "Más de un valor comparten la misma etiqueta de idioma. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@es ;
+        sh:message "More than one value shares the same language tag. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@en ;
     ],
 
     # foaf:page
@@ -283,8 +288,11 @@
     [
         sh:path dcat:mediaType ;
         sh:nodeKind sh:IRI ;
-        sh:node :IanaFormatRestriction;
+        sh:node dcatapes:IanaFormatRestriction;
         sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dcat_mediatype> ;
+        sh:message "El valor de dcat:mediaType debe ser un IRI válido del formato de tipos de medios de IANA."@es ;
+        sh:message "The value of dcat:mediaType must be a valid IRI from the IANA media types format."@en ;
     ], 
     [
         sh:path dcat:mediaType ;
@@ -320,7 +328,7 @@
         sh:path dct:issued ;
         sh:maxCount 1 ;
         sh:nodeKind sh:Literal ;
-        sh:node :DateOrDateTimeDataTypetConvention ;
+        sh:node dcatapes:DateOrDateTimeDataTypetConvention ;
         sh:severity sh:Violation ;
     ],
 
@@ -329,7 +337,7 @@
         sh:path dct:modified ;
         sh:maxCount 1 ;
         sh:nodeKind sh:Literal ;
-        sh:node :DateOrDateTimeDataTypetConvention ;
+        sh:node dcatapes:DateOrDateTimeDataTypetConvention ;
         sh:severity sh:Violation ;
     ], 
 
@@ -344,7 +352,7 @@
     ], 
     [
         sh:path adms:status ;
-        sh:node :StatusRestriction ;
+        sh:node dcatapes:StatusRestriction ;
         sh:nodeKind sh:IRI ;
         sh:severity sh:Violation ;
     ], 
@@ -352,7 +360,7 @@
     # dct:language
     [
         sh:path dct:language ;
-        sh:node :LanguageRestriction ;
+        sh:node dcatapes:LanguageRestriction ;
         sh:severity sh:Violation ;
     ], 
 
@@ -368,7 +376,10 @@
     [
         sh:path dcat:compressFormat ;
         sh:nodeKind sh:IRI ;
-        sh:node :IanaFormatRestriction;
+        sh:node dcatapes:IanaFormatRestriction;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dcat_compressformat> ;
+        sh:message "El valor de dcat:compressFormat debe ser un IRI válido del formato de tipos de medios de IANA."@es ;
+        sh:message "The value of dcat:compressFormat must be a valid IRI from the IANA media types format."@en ;
     ], 
     
     # dcat:packageFormat 
@@ -383,8 +394,10 @@
     [
         sh:path dcat:packageFormat ;
         sh:nodeKind sh:IRI ;
-        sh:node :IanaFormatRestriction;
-        sh:severity sh:Violation ;
+        sh:node dcatapes:IanaFormatRestriction;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dcat_packageformat> ;
+        sh:message "El valor de dcat:packageFormat debe ser un IRI válido del formato de tipos de medios de IANA."@es ;
+        sh:message "The value of dcat:packageFormat must be a valid IRI from the IANA media types format."@en ;
     ], 
 
     # dcat:byteSize
@@ -393,11 +406,11 @@
         sh:nodeKind sh:Literal;
         sh:or(
             [
-                sh:none :NonNegativeIntegerRestriction ;
+                sh:none dcatapes:NonNegativeIntegerRestriction ;
             ]
             [
-                sh:node :NonLiteralMultilingualConvention;
-                sh:node :NonEmptyLiteralConvention
+                sh:node dcatapes:NonLiteralMultilingualConvention;
+                sh:node dcatapes:NonEmptyLiteralConvention
             ]
         );
         sh:severity sh:Violation
@@ -439,7 +452,7 @@
         sh:path dcat:temporalResolution ;
         sh:nodeKind sh:Literal;
         sh:datatype xsd:duration ;
-        sh:node :DurationRestriction;
+        sh:node dcatapes:DurationRestriction;
     ],
     [
         sh:path dcat:temporalResolution ;
@@ -451,14 +464,6 @@
     ], 
 
     # spdx:checksum
-    [
-        sh:path spdx:checksum ;
-        sh:nodeKind sh:IRI ;
-        sh:severity sh:Violation ;
-        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-spdx_checksum> ;
-        sh:message "El valor de spdx:checksum debe ser un IRI válido para spdx:checksum."@es ;
-        sh:message "The value of spdx:checksum must be a valid IRI for spdx:checksum."@en ;
-    ],
     [
         sh:path spdx:checksum ;
         sh:class spdx:Checksum ;
@@ -505,7 +510,7 @@
     sh:targetClass dcat:Distribution .
 
 # Convencion 02
-:DistributionSPALanguageRestriction
+dcatapes:DistributionSPALanguageRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que una distribución cumpla con las convenciones de idioma y contenido en español, incluyendo título, descripción y otros elementos clave."@es ;
     rdfs:comment "Restriction to validate that a distribution complies with Spanish language and content conventions, including title, description, and other key elements."@en ;
@@ -513,15 +518,15 @@
     rdfs:label "Distribution restriction: Spanish language and content"@en ;
     sh:name "Distribution Spanish Language and Content Restriction"@en ;
     sh:name "Restricción de distribución: idioma y contenido en español"@es ;
-    sh:node :SpanishLanguageRestriction ;
-    sh:node :SpanishTitleRestriction ;
-    sh:node :SpanishDescriptionRestriction ;
+    sh:node dcatapes:SpanishLanguageRestriction ;
+    sh:node dcatapes:SpanishTitleRestriction ;
+    sh:node dcatapes:SpanishDescriptionRestriction ;
     sh:severity sh:Violation ;
     foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
     sh:targetClass dcat:Distribution .
 
 # Convencion 21
-:OGCServiceAccessURLRestriction
+dcatapes:OGCServiceAccessURLRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que las URLs de acceso a servicios OGC incluyan la operación GetCapabilities."@es ;
     rdfs:comment "Restriction to validate that OGC service access URLs include the GetCapabilities operation."@en ;
@@ -569,7 +574,7 @@
 #---------------------------
 # Other shape restrictions
 #---------------------------
-:Checksum_Shape
+dcatapes:Checksum_Shape
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que un recurso de tipo spdx:Checksum tenga un algoritmo definido y un valor de checksum válido."@es ;
     rdfs:comment "Restriction to validate that a resource of type spdx:Checksum has a defined algorithm and a valid checksum value."@en ;
@@ -599,7 +604,7 @@
     # spdx:checksumValue 
     [
         sh:path spdx:checksumValue ;
-        sh:node :NonEmptyLiteralConvention ;
+        sh:node dcatapes:NonEmptyLiteralConvention ;
         sh:datatype xsd:hexBinary ;
         sh:maxCount 1 ;
         sh:minCount 1 ;
@@ -611,7 +616,7 @@
     foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#spdx-checksum> ;
     sh:targetClass spdx:Checksum .
 
-:IMT_Shape
+dcatapes:IMT_Shape
     a sh:NodeShape ;
     rdfs:comment "Restricción heredada de NTI-RISP (2013) para validar que los valores de rdf:value y rdfs:label en recursos de tipo dct:IMT sean literales no vacíos y no multilingües."@es ;
     rdfs:comment "Restriction inherited from NTI-RISP (2013) to validate that the values of rdf:value and rdfs:label in resources of type dct:IMT are non-empty, non-multilingual literals."@en ;
@@ -623,12 +628,12 @@
     [
         sh:path rdf:value ;
         sh:nodeKind sh:Literal ;
-        sh:node :NonLiteralMultilingualConvention ;
+        sh:node dcatapes:NonLiteralMultilingualConvention ;
         sh:severity sh:Violation ;
     ],
     [
         sh:path rdf:value ;
-        sh:node :NonEmptyLiteralConvention ;
+        sh:node dcatapes:NonEmptyLiteralConvention ;
         sh:severity sh:Violation ;
     ],
     [
@@ -649,12 +654,12 @@
     [
         sh:path rdfs:label ;
         sh:nodeKind sh:Literal ;
-        sh:node :NonLiteralMultilingualConvention ;
+        sh:node dcatapes:NonLiteralMultilingualConvention ;
         sh:severity sh:Violation ;
     ],
     [
         sh:path rdfs:label ;
-        sh:node :NonEmptyLiteralConvention ;
+        sh:node dcatapes:NonEmptyLiteralConvention ;
         sh:severity sh:Violation ;
     ],
     [
@@ -677,7 +682,7 @@
 #--------------------------
 # Vocabulary restrictions
 #--------------------------
-:AvailabilityRestriction
+dcatapes:AvailabilityRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que el valor de dcatap:availability sea un IRI del vocabulario europeo de disponibilidad prevista."@es ;
     rdfs:comment "Restriction to validate that the value of dcatap:availability is an IRI from the European planned availability vocabulary."@en ;
@@ -691,7 +696,7 @@
     sh:message "The value of dcatap:availability must be an IRI from the European planned availability vocabulary: http://publications.europa.eu/resource/authority/planned-availability."@en ;
     sh:severity sh:Violation .
 
-:FileTypeRestriction
+dcatapes:FileTypeRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que el valor sea un IRI del vocabulario europeo de tipos de archivo."@es ;
     rdfs:comment "Restriction to validate that the value is an IRI from the European file type vocabulary."@en ;
@@ -705,7 +710,7 @@
     sh:message "The value of dct:format must be an IRI from the European file type vocabulary: http://publications.europa.eu/resource/authority/file-type."@en ;
     sh:severity sh:Violation .
 
-:IanaFormatRestriction
+dcatapes:IanaFormatRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que el valor sea un IRI válido que siga el formato de los tipos de medios definidos por IANA."@es ;
     rdfs:comment "Restriction to validate that the value is a valid IRI following the format of media types defined by IANA."@en ;
@@ -718,7 +723,7 @@
     sh:message "The value of dcat:mediaType must be a valid IRI from the IANA media types format."@en ;
     sh:severity sh:Violation .
 
-:StatusRestriction
+dcatapes:StatusRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción para validar que el valor de adms:status sea un IRI del vocabulario europeo de estados de distribución."@es ;
     rdfs:comment "Restriction to validate that the value of adms:status is an IRI from the European distribution status vocabulary."@en ;

--- a/shacl/1.0.0/shacl_mdr-vocabularies.shape.ttl
+++ b/shacl/1.0.0/shacl_mdr-vocabularies.shape.ttl
@@ -1,5 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix : <https://datosgobes.github.io/DCAT-AP-ES/> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix cc: <http://creativecommons.org/ns#> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
@@ -33,7 +32,7 @@
 #--------------------------
 # Vocabulary restrictions
 #--------------------------
-:AtuRestriction
+dcatapes:AtuRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción de unidad territorial administrativa"@es ;
     rdfs:comment "Administrative territorial unit restriction"@en ;
@@ -46,7 +45,7 @@
     sh:message "The value must be an IRI from the european Administrative territorial unit type vocabulary http://publications.europa.eu/resource/authority/atu"@en ;
     sh:severity sh:Violation .
 
-:ContinentRestriction
+dcatapes:ContinentRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción de continente"@es ;
     rdfs:comment "Continent restriction"@en ;
@@ -59,7 +58,7 @@
     sh:message "The value must be an IRI from the European continent vocabulary http://publications.europa.eu/resource/authority/continent"@en ;
     sh:severity sh:Violation .
 
-:CountryRestriction
+dcatapes:CountryRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción de país"@es ;
     rdfs:comment "Country restriction"@en ;
@@ -72,7 +71,7 @@
     sh:message "The value must be an IRI from the European country vocabulary http://publications.europa.eu/resource/authority/country"@en ;
     sh:severity sh:Violation .
 
-:AccessRightRestriction
+dcatapes:AccessRightRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción de derechos de acceso"@es ;
     rdfs:comment "Access Rights Restriction"@en ;
@@ -85,7 +84,7 @@
     sh:message "The value must be an IRI from the European access right vocabulary http://publications.europa.eu/resource/authority/access-right"@en ;
     sh:severity sh:Violation .
 
-:GeoNamesRestriction
+dcatapes:GeoNamesRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción de nombres geográficos"@es ;
     rdfs:comment "Geo names restriction"@en ;
@@ -98,7 +97,7 @@
     sh:message "The value must be an IRI from the geonames http://sws.geonames.org"@en ;
     sh:severity sh:Violation .
 
-:LanguageRestriction
+dcatapes:LanguageRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción de idioma"@es ;
     rdfs:comment "Language Restriction"@en ;
@@ -111,7 +110,7 @@
     sh:message "The value of dct:language must be an IRI from the European language vocabulary http://publications.europa.eu/resource/authority/language"@en ;
     sh:severity sh:Violation .
 
-:LicenceRestriction
+dcatapes:LicenceRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción de licencia"@es ;
     rdfs:comment "Licence restriction"@en ;
@@ -124,7 +123,7 @@
     sh:message "The value of dct:license must be an IRI from the European language vocabulary http://publications.europa.eu/resource/authority/licence"@en ;
     sh:severity sh:Violation .
 
-:LicenceTypeRestriction
+dcatapes:LicenceTypeRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción de tipo de licencia"@es ;
     rdfs:comment "Licence type restriction"@en ;
@@ -137,7 +136,7 @@
     sh:message "The value must be an IRI from the licence type vocabulary http://purl.org/adms/licencetype/1.0/"@en ;
     sh:severity sh:Violation .
 
-:TerritoryRestriction
+dcatapes:TerritoryRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción de territorio"@es ;
     rdfs:comment "Territory restriction"@en ;
@@ -223,7 +222,7 @@
     sh:message "The value must be an IRI from the NTI-RISP territory vocabulary http://datos.gob.es/recurso/sector-publico/territorio"@en ;
     sh:severity sh:Violation .
 
-:PlaceRestriction
+dcatapes:PlaceRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción de lugar"@es ;
     rdfs:comment "Place restriction"@en ;
@@ -237,7 +236,7 @@
     sh:severity sh:Violation .
 
 # Convencion 01
-:DIR3OrganismRestriction
+dcatapes:DIR3OrganismRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción de organismo del sector público"@es ;
     rdfs:comment "Public Sector Organism Restriction"@en ;
@@ -250,7 +249,7 @@
     sh:message "The value must be an IRI from the public sector organism vocabulary http://datos.gob.es/recurso/sector-publico/org/Organismo"@en ;
     sh:severity sh:Violation .
 
-:PublisherTypeRestriction
+dcatapes:PublisherTypeRestriction
     a sh:NodeShape ;
     rdfs:comment "Restricción de tipo de editor"@es ;
     rdfs:comment "Publisher type restriction"@en ;

--- a/shacl/README.md
+++ b/shacl/README.md
@@ -3,7 +3,7 @@
 Este directorio contiene los archivos de validación SHACL ([Shapes Constraint Language](https://www.w3.org/TR/shacl/)) para [comprobar la conformidad](https://datos.gob.es/es/blog/shacl-un-lenguaje-para-validar-grafos-rdf) con el perfil de aplicación [DCAT-AP-ES](https://github.com/datosgobes/DCAT-AP-ES).
 
 >[!TIP]
-> Más información sobre la validación de [DCAT-AP-ES](https://github.com/datosgobes/DCAT-AP-ES/validacion)  y sus ficheros SHACL.
+> Más información sobre la validación de [DCAT-AP-ES](https://datosgobes.github.io/DCAT-AP-ES/validacion)  y sus ficheros SHACL.
 
 ## Contenido
 
@@ -14,7 +14,6 @@ El repositorio incluye los siguientes archivos SHACL:
 - `shacl_dataservice_shape.ttl`: Restricciones para servicios de datos
 - `shacl_dataset_shape.ttl`: Restricciones para conjuntos de datos
 - `shacl_distribution_shape.ttl`: Restricciones para distribuciones
-- `shacl_dataservice_shape.ttl`: Restricciones para servicios de datos
 - `shacl_mdr-vocabularies.shape.ttl`: Vocabularios controlados y sus restricciones
 - `shacl_imports.ttl`: Definiciones de importación para ontologías externas
 - `shacl_mdr_imports.ttl`: Definiciones de importación para vocabularios MDR


### PR DESCRIPTION
- Actualización de todas las apariciones del prefijo predeterminado (":") a dcatapes en shacl_dataset_shape.ttl, shacl_distribution_shape.ttl y shacl_mdr-vocabularies.shape.ttl.
- Se ha mejorado la compatibilidad multilingüe añadiendo mensajes para las restricciones de idioma únicas en las formas de conjunto de datos y distribución.
- Se ha mejorado la documentación de README.md para reflejar las URL correctas de los recursos de validación.
- Se han eliminado entradas redundantes y se ha garantizado que todas las formas estén correctamente definidas con las restricciones adecuadas.