### PR TITLE
Mejoras de la documentación

### DIFF
--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -803,6 +803,55 @@ a:hover, a:focus {
     }
 }
 
+/* Global warning banner */
+.warning-banner {
+  background-color: #fff4e5;
+  color: var(--header-bg-color);
+  text-align: center;
+  padding: 12px 24px;
+  font-size: 16px;
+  width: 100%;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  line-height: 1.4;
+  border-bottom: var(--warning-bg-color) 2px solid;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.warning-banner a {
+  font-weight: bold;
+}
+
+.warning-banner a:hover {
+  text-decoration: none;
+  color: var(--warning-bg-color);
+}
+
+.warning-banner .twemoji {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+}
+
+.warning-banner .twemoji svg {
+  height: 22px;
+  width: 22px;
+  fill: var(--warning-bg-color);
+  vertical-align: middle;
+  margin-top: -2px; /* Ajusta ligeramente para centrar perfectamente */
+}
+
+/* Para pantallas pequeñas ajusta el diseño */
+@media screen and (max-width: 768px) {
+  .warning-banner {
+    flex-direction: column;
+    padding: 8px 16px;
+  }
+}
 /* Draft Ribbon */
 .draft-ribbon {
     position: fixed;
@@ -836,4 +885,47 @@ a:hover, a:focus {
         font-size: 11px;
         padding: 8px 4px;
     }
+}
+
+/* Force visibility for period text */
+.header-summary dd span.period-start,
+.header-summary dd span.period-end {
+    color: #000000 !important; 
+    font-size: 1em !important; 
+    opacity: 1 !important; 
+    visibility: visible !important;
+    text-indent: 0 !important;
+    display: inline !important;
+    background: none !important; 
+    border-bottom: 1px dotted #555 !important; 
+    padding: 0 !important; 
+    margin: 0 !important; 
+}
+
+.header-summary dd {
+    color: #333 !important; 
+    font-size: 1em !important;
+    opacity: 1 !important;
+    visibility: visible !important;
+}
+
+/* Header title style - Enhanced */
+.md-header__topic .md-ellipsis {
+    font-size: 0.95rem; 
+    font-weight: 400; 
+    color: var(--blue-aporta);
+    letter-spacing: 0.5px; 
+    opacity: 0.75; 
+    text-overflow: ellipsis; 
+    transition: opacity 0.2s; /* Transición suave */
+}
+
+.md-header__topic .md-ellipsis:hover {
+    opacity: 1; 
+}
+
+/* Asegurar alineación vertical si es necesario */
+.md-header__title {
+    display: flex;
+    align-items: center; 
 }

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -10,6 +10,9 @@
     --warning-bg-color: #ff8822;
     --alternate-bg-color: #eee;
     --alternate-table-color--light: rgb(201 226 223 / 50%) !important;
+    --red-aporta: #e5013e;
+    --red-aporta-light: #f5d0d6;
+    --blue-aporta: #154481;
 
     /* Admonition Icons */
     --md-admonition-icon--must: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path fill="red" d="M256 8c137 0 248 111 248 248S393 504 256 504 8 393 8 256 119 8 256 8zm0 120c-17.7 0-32 14.3-32 32v96c0 17.7 14.3 32 32 32s32-14.3 32-32v-96c0-17.7-14.3-32-32-32zm0 240c-17.7 0-32 14.3-32 32s14.3 32 32 32 32-14.3 32-32-14.3-32-32-32z"/></svg>');
@@ -218,7 +221,7 @@ a:hover, a:focus {
 }
 .md-typeset .must > .admonition-title,
 .md-typeset .must > summary {
-    background-color: #eba58f33; 
+    background-color: #eba58f50; 
     color: #63453b;
     display: flex;
     justify-content: space-between;
@@ -797,5 +800,40 @@ a:hover, a:focus {
     }
     75% {
         transform: scale(1.2);
+    }
+}
+
+/* Draft Ribbon */
+.draft-ribbon {
+    position: fixed;
+    top: 60px;
+    right: -58px;
+    width: 284px;
+    background-color: var(--red-aporta);
+    color: var(--red-aporta-light);
+    text-align: center;
+    transform: rotate(45deg);
+    font-size: 14px;
+    font-weight: bold;
+    text-transform: uppercase;
+    padding: 13px 0;
+    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.3);
+    z-index: 1000;
+    letter-spacing: 0.5px;
+    white-space: normal;
+    word-break: break-word; 
+    line-height: 1.3;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* Responsive */
+@media screen and (max-width: 600px) {
+    .draft-ribbon {
+        top: 8px;
+        right: -70px;
+        width: 180px;
+        font-size: 11px;
+        padding: 8px 4px;
     }
 }

--- a/docs/conventions.en.md
+++ b/docs/conventions.en.md
@@ -75,7 +75,9 @@ These conventions ensure consistency in the description of resources, guaranteei
 - [**Convention 20**](#convention-20): In OGC service distributions, access URLs *MUST* be modeled as follows:
     - In `dcat:accessURL`: Complete URL of the service `GetCapabilities` request (e.g., `http://example.org/wms?request=GetCapabilities&service=WMS`)
     - In `dct:conformsTo`: URL of the corresponding OGC standard (e.g., `http://www.opengeospatial.org/standards/wms`)
-
+- [**Convention 20**](#convention-20): Contact points listed in the portal's taxonomy *MUST* be described as a `vcard:Kind` and not directly with the organization's URI.
+- [**Convention 21**](#convention-21): In OGC service distributions, access URLs *MUST* be modeled as follows: In `dcat:accessURL`: Complete URL of the service `GetCapabilities` request (e.g., `http://example.org/wms?request=GetCapabilities&service=WMS`) and in `dct:conformsTo`: URL of the corresponding OGC standard, e.g., `http://www.opengeospatial.org/standards/wms`.
+- [**Convention 22**](#convention-22): Time periods *MUST* be described exclusively using the properties `dcat:startDate` and `dcat:endDate` within `dct:temporal`. The interval can also be open - i.e., it can have just a start or just an end.
 
 # General conventions {#general}
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -46,7 +46,7 @@ Estas convenciones aseguran la coherencia en la descripción de los recursos, ga
 - [**Convención 19**](#convencion-19): El punto de contacto *DEBERÍA* incluir también: 1. Denominación del área o persona (`vcard:fn`) 2. Número de teléfono (`vcard:hasTelephone`) 3. Identificador del organismo (`vcard:hasUid`)
 - [**Convención 20**](#convencion-20): Los puntos de contacto recogidos en la taxonomía del portal *DEBEN* describirse como un `vcard:Kind` y no directamente con la URI del organismo.
 - [**Convención 21**](#convencion-21): En las distribuciones de servicios OGC, las URLs de acceso *DEBEN* modelarse de la siguiente manera: En `dcat:accessURL`: URL completa de la petición de capacidades del servicio `GetCapabilities` (ej: `http://example.org/wms?request=GetCapabilities&service=WMS`) y en `dct:conformsTo`: URL del estándar OGC correspondiente, ej: `http://www.opengeospatial.org/standards/wms`
-- [**Convención 22**](#convencion-22): Los periodos temporales *DEBEN* ser descritos exclusivamente mediante las propiedades `dcat:startDate` y `dcat:endDate` dentro de `dct:temporal`.
+- [**Convención 22**](#convencion-22): Los periodos temporales *DEBEN* ser descritos exclusivamente mediante las propiedades `dcat:startDate` y `dcat:endDate` dentro de `dct:temporal`. El intervalo también puede ser abierto, es decir, puede tener solo un comienzo o solo un final.
 
 
 # Convenciones generales {#general}
@@ -228,7 +228,7 @@ Dado que tanto `dcat:startDate` como `dcat:endDate` pueden registrarse con [rang
 
 
 !!! must organisational "Convención 22"
-    Los periodos temporales **DEBEN** ser descritos exclusivamente mediante las propiedades `dcat:startDate` y `dcat:endDate` dentro de `dct:temporal`.
+    Los periodos temporales **DEBEN** ser descritos exclusivamente mediante las propiedades `dcat:startDate` y `dcat:endDate` dentro de `dct:temporal`. El intervalo también puede ser abierto, es decir, puede tener solo un comienzo o solo un final.
 
 !!! info "Ejemplo de uso correcto de un período temporal"
     ```turtle linenums="1"

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -584,6 +584,7 @@ Los prefijos listados son los más comúnmente utilizados, aunque técnicamente 
 | `prov` | `http://www.w3.org/ns/prov#` | Provenance Ontology | Trazabilidad y procedencia de datos |
 | `rdf` | `http://www.w3.org/1999/02/22-rdf-syntax-ns#` | RDF Schema | Vocabulario básico para definir recursos RDF |
 | `rdfs` | `http://www.w3.org/2000/01/rdf-schema#` | RDF Schema | Extensión de RDF para definir clases y propiedades |
+| `schema` | `http://schema.org/` | Schema.org | Vocabulario para estructurar datos en la web |
 | `skos` | `http://www.w3.org/2004/02/skos/core#` | SKOS | Sistema de organización del conocimiento |
 | `spdx` | `http://spdx.org/rdf/terms#` | Software Package Data Exchange | Licencias y paquetes de software |
 | `time` | `http://www.w3.org/2006/time#` | Time Ontology | Conceptos temporales y duraciones |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -148,6 +148,38 @@ Secciones:
     
     [:octicons-arrow-right-24: PAe](https://administracionelectronica.gob.es/pae_Home/pae_Biblioteca/pae_PublicacionesPropias/Monografias-administracion-electronica/Guias-de-aplicacion-NTI.html)
 
+-   :material-update:{ .lg .middle .grid-emoji } **¿ Cómo evoluciono desde un catálogo NTI-RISP?**{ .grid-title #migracion-nti }
+
+    ---
+
+    Si ya tienes un catálogo conforme al modelo de metadatos NTI-RISP 2013, para evolucionar a DCAT-AP-ES puedes:
+    
+    1. **Identificar cambios**: Revisar las diferencias entre ambos modelos según el [Anexo 1 - Cambios respecto a la NTI-RISP](/#annex-1-nti-risp-to-dcat-ap-es) e incorporar nuevos metadatos obligatorios.
+    
+    2. **Adaptar vocabularios controlados**: Utilizar los [vocabularios actualizados del modelo](/#dcat-ap-es-vocabularies) en vez de literales.
+    
+    3. **Añadir soporte a servicios**: Incorporar la clase [`dcat:DataService`](/#servicio_de_datos_-_clase_dcatdataservice_-_opcional) si ofreces APIs o servicios.
+    
+    4. **Validar el catálogo**: Comprobar la conformidad utilizando las [herramientas de validación](/validacion/)
+    
+    [:octicons-arrow-right-24: Migración](/#annex-1-nti-risp-to-dcat-ap-es)
+
+-   :material-compare:{ .lg .middle .grid-emoji } **¿ Diferencias entre DCAT-AP-ES y DCAT-AP?**{ .grid-title #diferencias-dcat }
+
+    ---
+
+    DCAT-AP-ES añade varias restricciones y extiende el modelo europeo:
+    
+    - **Obligatoriedad ampliada**: Establece más propiedades obligatorias para garantizar la interoperabilidad.
+    
+    - **Contexto español**: Añade taxonomías y vocabularios controlados propios del sector público español.
+    
+    - **Integración HVD**: Incorpora completamente el modelo de datos de alto valor.
+    
+    - **Cardinalidad adaptada**: Limita algunas cardinalidades para descripciones más precisas.
+    
+    [:octicons-arrow-right-24: Diferencias](/#annex-3-dcat-ap-to-dcat-ap-es)
+
 </div>
 
 ## **Modelo de datos** { .faq-h #model}

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -112,7 +112,7 @@ Secciones:
 
     ---
 
-    Los publicadores disponen de un periodo de adaptación de seis meses desde la entrada en vigor de la NTI-RISP.
+    Los publicadores disponen de un periodo de adaptación desde la entrada en vigor de la NTI-RISP.
     
     [:octicons-arrow-right-24: Cambios](/#annex-1-nti-risp-to-dcat-ap-es)
 

--- a/docs/img/uml/dcat-ap-es.drawio
+++ b/docs/img/uml/dcat-ap-es.drawio
@@ -1,6 +1,6 @@
 <mxfile host="65bd71144e">
     <diagram id="C5RBs43oDa-KdzZeNtuy" name="Page-1">
-        <mxGraphModel dx="153" dy="188" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1654" pageHeight="2336" math="0" shadow="0">
+        <mxGraphModel dx="697" dy="788" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1654" pageHeight="2336" math="0" shadow="0">
             <root>
                 <mxCell id="WIyWlLk6GJQsqaUBKTNV-0"/>
                 <mxCell id="WIyWlLk6GJQsqaUBKTNV-1" parent="WIyWlLk6GJQsqaUBKTNV-0"/>
@@ -33,19 +33,19 @@
                 <mxCell id="zkfFHV4jXpPFQw0GAbJ--19" value="dcat:accessURL [1..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rounded=0;shadow=0;html=0;fontSize=11;fontStyle=0" parent="zkfFHV4jXpPFQw0GAbJ--17" vertex="1">
                     <mxGeometry y="64" width="220" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="Nw97LbCy2OWGeZqUpTsd-26" value="dcatap:applicableLegislation (HVD) [1..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="zkfFHV4jXpPFQw0GAbJ--17" vertex="1">
+                <mxCell id="zkfFHV4jXpPFQw0GAbJ--20" value="&lt;&lt;recomendado&gt;&gt;" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rounded=0;shadow=0;html=0;fontStyle=1;fontSize=11;" parent="zkfFHV4jXpPFQw0GAbJ--17" vertex="1">
                     <mxGeometry y="90" width="220" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="zkfFHV4jXpPFQw0GAbJ--20" value="&lt;&lt;recomendado&gt;&gt;" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rounded=0;shadow=0;html=0;fontStyle=1;fontSize=11;" parent="zkfFHV4jXpPFQw0GAbJ--17" vertex="1">
+                <mxCell id="zkfFHV4jXpPFQw0GAbJ--21" value="dct:description [0..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rounded=0;shadow=0;html=0;fontSize=11;" parent="zkfFHV4jXpPFQw0GAbJ--17" vertex="1">
                     <mxGeometry y="116" width="220" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="zkfFHV4jXpPFQw0GAbJ--21" value="dct:description [0..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rounded=0;shadow=0;html=0;fontSize=11;" parent="zkfFHV4jXpPFQw0GAbJ--17" vertex="1">
+                <mxCell id="zkfFHV4jXpPFQw0GAbJ--22" value="dcatap:availability [0..1]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rounded=0;shadow=0;html=0;fontSize=11;" parent="zkfFHV4jXpPFQw0GAbJ--17" vertex="1">
                     <mxGeometry y="142" width="220" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="zkfFHV4jXpPFQw0GAbJ--22" value="dcatap:availability [0..1]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rounded=0;shadow=0;html=0;fontSize=11;" parent="zkfFHV4jXpPFQw0GAbJ--17" vertex="1">
+                <mxCell id="zkfFHV4jXpPFQw0GAbJ--24" value="dct:format [0..1]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="zkfFHV4jXpPFQw0GAbJ--17" vertex="1">
                     <mxGeometry y="168" width="220" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="zkfFHV4jXpPFQw0GAbJ--24" value="dct:format [0..1]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="zkfFHV4jXpPFQw0GAbJ--17" vertex="1">
+                <mxCell id="2" value="dcatap:applicableLegislation [0..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" vertex="1" parent="zkfFHV4jXpPFQw0GAbJ--17">
                     <mxGeometry y="194" width="220" height="26" as="geometry"/>
                 </mxCell>
                 <mxCell id="zkfFHV4jXpPFQw0GAbJ--25" value="&lt;&lt;opcional&gt;&gt;" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;fontStyle=1" parent="zkfFHV4jXpPFQw0GAbJ--17" vertex="1">
@@ -87,7 +87,7 @@
                 <mxCell id="G__cIaLFMgHAqbE_2iN8-3" value="dcat:packageFormat [0..1]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="zkfFHV4jXpPFQw0GAbJ--17" vertex="1">
                     <mxGeometry y="532" width="220" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="G__cIaLFMgHAqbE_2iN8-4" value="dcat:spatialResolutionInMeters [0..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="zkfFHV4jXpPFQw0GAbJ--17" vertex="1">
+                <mxCell id="G__cIaLFMgHAqbE_2iN8-4" value="dcat:spatialResolutionInMeters [0..1]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="zkfFHV4jXpPFQw0GAbJ--17" vertex="1">
                     <mxGeometry y="558" width="220" height="26" as="geometry"/>
                 </mxCell>
                 <mxCell id="G__cIaLFMgHAqbE_2iN8-5" value="dcat:temporalResolution [0..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="zkfFHV4jXpPFQw0GAbJ--17" vertex="1">
@@ -139,13 +139,13 @@
                 <mxCell id="G__cIaLFMgHAqbE_2iN8-21" value="dcat:contactPoint [0..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rounded=0;shadow=0;html=0;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-16" vertex="1">
                     <mxGeometry y="246" width="250" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="G__cIaLFMgHAqbE_2iN8-29" value="dct:issued [0..1]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-16" vertex="1">
+                <mxCell id="G__cIaLFMgHAqbE_2iN8-24" value="&lt;&lt;opcional&gt;&gt;" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;fontStyle=1" parent="G__cIaLFMgHAqbE_2iN8-16" vertex="1">
                     <mxGeometry y="272" width="250" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="G__cIaLFMgHAqbE_2iN8-30" value="dct:modified [0..1]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-16" vertex="1">
+                <mxCell id="G__cIaLFMgHAqbE_2iN8-29" value="dct:issued [0..1]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-16" vertex="1">
                     <mxGeometry y="298" width="250" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="G__cIaLFMgHAqbE_2iN8-24" value="&lt;&lt;opcional&gt;&gt;" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;fontStyle=1" parent="G__cIaLFMgHAqbE_2iN8-16" vertex="1">
+                <mxCell id="G__cIaLFMgHAqbE_2iN8-30" value="dct:modified [0..1]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-16" vertex="1">
                     <mxGeometry y="324" width="250" height="26" as="geometry"/>
                 </mxCell>
                 <mxCell id="G__cIaLFMgHAqbE_2iN8-25" value="dct:identifier [0..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-16" vertex="1">
@@ -181,7 +181,7 @@
                 <mxCell id="G__cIaLFMgHAqbE_2iN8-36" value="dcat:qualifiedRelation [0..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-16" vertex="1">
                     <mxGeometry y="610" width="250" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="G__cIaLFMgHAqbE_2iN8-37" value="dcat:spatialResolutionInMeters [0..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-16" vertex="1">
+                <mxCell id="G__cIaLFMgHAqbE_2iN8-37" value="dcat:spatialResolutionInMeters [0..1]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-16" vertex="1">
                     <mxGeometry y="636" width="250" height="26" as="geometry"/>
                 </mxCell>
                 <mxCell id="G__cIaLFMgHAqbE_2iN8-38" value="dcat:temporalResolution [0..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-16" vertex="1">
@@ -202,11 +202,8 @@
                 <mxCell id="G__cIaLFMgHAqbE_2iN8-41" value="prov:wasGeneratedBy [0..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-16" vertex="1">
                     <mxGeometry y="792" width="250" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="G__cIaLFMgHAqbE_2iN8-42" value="dct:accrualPeriodicity [0..1]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-16" vertex="1">
-                    <mxGeometry y="818" width="250" height="26" as="geometry"/>
-                </mxCell>
                 <mxCell id="G__cIaLFMgHAqbE_2iN8-45" value="dct:accessRights [0..1]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-16" vertex="1">
-                    <mxGeometry y="844" width="250" height="26" as="geometry"/>
+                    <mxGeometry y="818" width="250" height="26" as="geometry"/>
                 </mxCell>
                 <mxCell id="G__cIaLFMgHAqbE_2iN8-50" value="&lt;&lt;recomendado&gt;&gt;&#xa;dct:LicenseDocument&#xa;" style="swimlane;fontStyle=0;align=center;verticalAlign=top;childLayout=stackLayout;horizontal=1;startSize=40;horizontalStack=0;resizeParent=1;resizeLast=0;collapsible=1;marginBottom=0;rounded=0;shadow=0;strokeWidth=1;fillColor=#f5f5f5;fontColor=#333333;strokeColor=#666666;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
                     <mxGeometry x="1270" y="38" width="260" height="92" as="geometry">
@@ -220,7 +217,7 @@
                     <mxGeometry y="66" width="260" height="26" as="geometry"/>
                 </mxCell>
                 <mxCell id="G__cIaLFMgHAqbE_2iN8-57" value="&lt;&lt;opcional&gt;&gt;&#xa;dcat:DataService" style="swimlane;fontStyle=1;align=center;verticalAlign=top;childLayout=stackLayout;horizontal=1;startSize=38;horizontalStack=0;resizeParent=1;resizeLast=0;collapsible=1;marginBottom=0;rounded=0;shadow=0;strokeWidth=1;fillColor=#f5f5f5;fontColor=#333333;strokeColor=#666666;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
-                    <mxGeometry x="755" y="1020.51" width="230" height="538" as="geometry">
+                    <mxGeometry x="755" y="1020.51" width="230" height="469.49" as="geometry">
                         <mxRectangle x="590" y="42" width="160" height="26" as="alternateBounds"/>
                     </mxGeometry>
                 </mxCell>
@@ -236,47 +233,38 @@
                 <mxCell id="Nw97LbCy2OWGeZqUpTsd-3" value="dcatap:hvdCategory (HVD) [1..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-57" vertex="1">
                     <mxGeometry y="116" width="230" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="Nw97LbCy2OWGeZqUpTsd-4" value="dcatap:applicableLegislation (HVD) [1..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-57" vertex="1">
+                <mxCell id="Nw97LbCy2OWGeZqUpTsd-6" value="dcat:contactPoint (HVD) [1..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-57" vertex="1">
                     <mxGeometry y="146" width="230" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="Nw97LbCy2OWGeZqUpTsd-6" value="dcat:contactPoint (HVD) [1..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-57" vertex="1">
+                <mxCell id="Nw97LbCy2OWGeZqUpTsd-7" value="foaf:page (HVD) [1..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-57" vertex="1">
                     <mxGeometry y="176" width="230" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="Nw97LbCy2OWGeZqUpTsd-7" value="foaf:page (HVD) [1..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-57" vertex="1">
+                <mxCell id="LO64hYzW_fXo8r1-_LwU-5" value="dcat:theme [1..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-57" vertex="1">
                     <mxGeometry y="206" width="230" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="LO64hYzW_fXo8r1-_LwU-5" value="dcat:theme [1..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-57" vertex="1">
-                    <mxGeometry y="236" width="230" height="30" as="geometry"/>
-                </mxCell>
-                <mxCell id="LO64hYzW_fXo8r1-_LwU-6" value="dct:publisher [1..1]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-57" vertex="1">
-                    <mxGeometry y="266" width="230" height="30" as="geometry"/>
-                </mxCell>
-                <mxCell id="swZq3jRaT1kj8TktFzxu-0" value="dcat:servesDataset (HVD) [1..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-57" vertex="1">
-                    <mxGeometry y="296" width="230" height="26" as="geometry"/>
-                </mxCell>
                 <mxCell id="G__cIaLFMgHAqbE_2iN8-62" value="&lt;&lt;recomendado&gt;&gt;" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rounded=0;shadow=0;html=0;fontSize=11;fontStyle=1" parent="G__cIaLFMgHAqbE_2iN8-57" vertex="1">
-                    <mxGeometry y="322" width="230" height="26" as="geometry"/>
+                    <mxGeometry y="236" width="230" height="26" as="geometry"/>
                 </mxCell>
                 <mxCell id="BrOEmKaO7y7j9zNrJ8Gz-0" value="dcat:servesDataset [0..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-57" vertex="1">
-                    <mxGeometry y="348" width="230" height="26" as="geometry"/>
+                    <mxGeometry y="262" width="230" height="26" as="geometry"/>
                 </mxCell>
                 <mxCell id="G__cIaLFMgHAqbE_2iN8-63" value="dcat:endpointDescription [0..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-57" vertex="1">
-                    <mxGeometry y="374" width="230" height="26" as="geometry"/>
+                    <mxGeometry y="288" width="230" height="26" as="geometry"/>
+                </mxCell>
+                <mxCell id="3" value="dcatap:applicableLegislation [0..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" vertex="1" parent="G__cIaLFMgHAqbE_2iN8-57">
+                    <mxGeometry y="314" width="230" height="30" as="geometry"/>
                 </mxCell>
                 <mxCell id="G__cIaLFMgHAqbE_2iN8-64" value="&lt;&lt;opcional&gt;&gt;" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;fontStyle=1" parent="G__cIaLFMgHAqbE_2iN8-57" vertex="1">
-                    <mxGeometry y="400" width="230" height="26" as="geometry"/>
+                    <mxGeometry y="344" width="230" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="LO64hYzW_fXo8r1-_LwU-4" value="dcat:keyword [0..1]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=1;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;movable=1;resizable=1;deletable=1;editable=1;locked=0;connectable=1;" parent="G__cIaLFMgHAqbE_2iN8-57" vertex="1">
-                    <mxGeometry y="426" width="230" height="30" as="geometry"/>
+                <mxCell id="LO64hYzW_fXo8r1-_LwU-4" value="dcat:keyword [0..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=1;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;movable=1;resizable=1;deletable=1;editable=1;locked=0;connectable=1;" parent="G__cIaLFMgHAqbE_2iN8-57" vertex="1">
+                    <mxGeometry y="370" width="230" height="30" as="geometry"/>
                 </mxCell>
                 <mxCell id="G__cIaLFMgHAqbE_2iN8-73" value="dct:accessRights [0..1]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=1;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;movable=1;resizable=1;deletable=1;editable=1;locked=0;connectable=1;" parent="G__cIaLFMgHAqbE_2iN8-57" vertex="1">
-                    <mxGeometry y="456" width="230" height="30" as="geometry"/>
+                    <mxGeometry y="400" width="230" height="30" as="geometry"/>
                 </mxCell>
                 <mxCell id="G__cIaLFMgHAqbE_2iN8-65" value="dct:description [0..n]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-57" vertex="1">
-                    <mxGeometry y="486" width="230" height="26" as="geometry"/>
-                </mxCell>
-                <mxCell id="KP87vVrYD7smni4kBXjM-1" value="dct:license [0..1]" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" parent="G__cIaLFMgHAqbE_2iN8-57" vertex="1">
-                    <mxGeometry y="512" width="230" height="26" as="geometry"/>
+                    <mxGeometry y="430" width="230" height="26" as="geometry"/>
                 </mxCell>
                 <mxCell id="G__cIaLFMgHAqbE_2iN8-87" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.887;entryY=1;entryDx=0;entryDy=0;entryPerimeter=0;fontSize=11;fontColor=#000000;endArrow=open;endFill=0;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="G__cIaLFMgHAqbE_2iN8-62" target="G__cIaLFMgHAqbE_2iN8-52" edge="1">
                     <mxGeometry relative="1" as="geometry"/>
@@ -361,7 +349,7 @@
                         </Array>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="gNaJxkc7meoPZ9sQGeCP-12" value="dct:haspart&lt;br&gt;&amp;lt;&amp;lt;opcional&amp;gt;&amp;gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=11;" parent="gNaJxkc7meoPZ9sQGeCP-11" connectable="0" vertex="1">
+                <mxCell id="gNaJxkc7meoPZ9sQGeCP-12" value="dct:hasPart&lt;br&gt;&amp;lt;&amp;lt;opcional&amp;gt;&amp;gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=11;" parent="gNaJxkc7meoPZ9sQGeCP-11" connectable="0" vertex="1">
                     <mxGeometry x="-0.6974" y="-2" relative="1" as="geometry">
                         <mxPoint x="19" as="offset"/>
                     </mxGeometry>
@@ -536,8 +524,8 @@
                 <mxCell id="G__cIaLFMgHAqbE_2iN8-187" value="dct:creator&lt;br&gt;&amp;lt;&amp;lt;opcional&amp;gt;" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=11;fontColor=#000000;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
                     <mxGeometry x="355" y="860" width="80" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="G__cIaLFMgHAqbE_2iN8-189" value="0..1" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=11;fontColor=#000000;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
-                    <mxGeometry x="430" y="870" width="30" height="20" as="geometry"/>
+                <mxCell id="G__cIaLFMgHAqbE_2iN8-189" value="0..n" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=11;fontColor=#000000;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+                    <mxGeometry x="425" y="865" width="40" height="30" as="geometry"/>
                 </mxCell>
                 <mxCell id="G__cIaLFMgHAqbE_2iN8-191" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fontSize=11;fontColor=#000000;endArrow=open;endFill=0;startArrow=none;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="G__cIaLFMgHAqbE_2iN8-192" edge="1">
                     <mxGeometry relative="1" as="geometry">
@@ -668,8 +656,8 @@
                 <mxCell id="G__cIaLFMgHAqbE_2iN8-235" value="1..1" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=11;fontColor=#000000;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
                     <mxGeometry x="580" y="745" width="40" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="G__cIaLFMgHAqbE_2iN8-236" value="0..1" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=11;fontColor=#000000;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
-                    <mxGeometry x="655" y="750" width="30" height="20" as="geometry"/>
+                <mxCell id="G__cIaLFMgHAqbE_2iN8-236" value="0..n" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=11;fontColor=#000000;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+                    <mxGeometry x="650" y="745" width="40" height="30" as="geometry"/>
                 </mxCell>
                 <mxCell id="G__cIaLFMgHAqbE_2iN8-237" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.043;entryDx=0;entryDy=0;entryPerimeter=0;fontSize=11;fontColor=#000000;endArrow=open;endFill=0;" parent="WIyWlLk6GJQsqaUBKTNV-1" target="zkfFHV4jXpPFQw0GAbJ--17" edge="1">
                     <mxGeometry relative="1" as="geometry">
@@ -830,10 +818,10 @@
                         <mxPoint x="600" y="930" as="targetPoint"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="Nw97LbCy2OWGeZqUpTsd-18" value="dct:publisher&lt;br&gt;&amp;lt;&amp;lt;&lt;span style=&quot;background-color: rgb(248, 249, 250);&quot;&gt;recomendado&lt;/span&gt;&amp;gt;&amp;gt;" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=11;fontColor=#000000;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
-                    <mxGeometry x="515" y="1103.51" width="120" height="40" as="geometry"/>
+                <mxCell id="Nw97LbCy2OWGeZqUpTsd-18" value="dct:publisher&lt;br&gt;&amp;lt;&amp;lt;&lt;span style=&quot;background-color: rgb(248, 249, 250);&quot;&gt;obligatorio&lt;/span&gt;&amp;gt;&amp;gt;" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=11;fontColor=#000000;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+                    <mxGeometry x="525" y="1103.51" width="100" height="40" as="geometry"/>
                 </mxCell>
-                <mxCell id="Nw97LbCy2OWGeZqUpTsd-21" value="0..1" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=11;fontColor=#000000;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+                <mxCell id="Nw97LbCy2OWGeZqUpTsd-21" value="1..1" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=11;fontColor=#000000;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
                     <mxGeometry x="580" y="954" width="40" height="30" as="geometry"/>
                 </mxCell>
                 <mxCell id="Nw97LbCy2OWGeZqUpTsd-23" value="" style="endArrow=none;html=1;rounded=0;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="G__cIaLFMgHAqbE_2iN8-178" edge="1">

--- a/docs/index.md
+++ b/docs/index.md
@@ -2215,5 +2215,155 @@ En la siguiente relación, se incluye junto al acrónimo HVD, las propiedades qu
 | Standard | dct:Standard |  |
 | Status | skos:Concept |  |
 
+# Anexo 3. Diferencias entre DCAT-AP-ES y DCAT-AP {#annex-3-dcat-ap-to-dcat-ap-es}
+
+DCAT-AP-ES se basa en [DCAT-AP 2.1.1](https://interoperable-europe.ec.europa.eu/collection/semic-support-centre/solution/dcat-application-profile-data-portals-europe/release/211) con la incorporación de elementos de la extensión [DCAT-AP HVD 2.2.0](https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd/). A continuación, se presentan las principales diferencias entre el modelo español y las versiones europeas.
+
+Las diferencias se muestran en las siguientes tablas comparativas, donde la cabecera indica:
+
+- **Entidad**: Clase o elemento del modelo (por ejemplo, `Catalog`, `Dataset`, `Distribution`, etc.).
+- **Metadato**: Nombre del metadato o propiedad.
+- **Propiedad**: Nombre formal de la propiedad (por ejemplo, `dct:title`).
+- **T** (Aplicabilidad): Tipo de obligatoriedad en DCAT-AP-ES (`Obligatorio`, `Recomendado`, `Opcional`).
+- **DCAT-AP T**: Tipo de obligatoriedad en el perfil DCAT-AP.
+- **C** (Cardinalidad): Cardinalidad en DCAT-AP-ES.
+- **DCAT-AP C**: Cardinalidad en el perfil DCAT-AP.
+- **Observaciones**: Comentarios sobre el cambio o diferencia principal.
+
+## DCAT-AP 2.1.1
+
+| Entidad | Metadato | Propiedad | T | DCAT-AP<br>T | C | DCAT-AP<br>C | Observaciones |
+|---|---|---|---|---|---|---|---|
+| Catalog | Nombre | dct:title | Ob | Ob | 1..n | 1..n | Sin cambios significativos |
+| Catalog | Descripción | dct:description | Ob | Ob | 1..n | 1..n | Sin cambios significativos |
+| Catalog | Órgano publicador | dct:publisher | Ob | Ob | 1..1 | 1..1 | Sin cambios significativos |
+| Catalog | Temática(s) | dcat:themeTaxonomy | Ob | R | 1..3 | 0..n | DCAT-AP-ES requiere obligatoriamente la [taxonomía de sectores primarios](http://datos.gob.es/kos/sector-publico/sector) y restringe cardinalidad |
+| Catalog | Idioma(s) | dct:language | Ob | R | 1..n | 0..n | DCAT-AP-ES exige que al menos uno de los idiomas sea español |
+| Catalog | Fecha de creación | dct:issued | Ob | R | 1..1 | 0..1 | DCAT-AP-ES eleva la propiedad a Obligatoria |
+| Catalog | Fecha de actualización | dct:modified | Ob | R | 1..1 | 0..1 | DCAT-AP-ES eleva la propiedad a Obligatoria |
+| Catalog | Página web | foaf:homepage | Ob | R | 1..1 | 0..1 | DCAT-AP-ES eleva la propiedad a Obligatoria |
+| Catalog | Términos de uso | dct:license | Ob | R | 1..1 | 0..1 | DCAT-AP-ES eleva la propiedad a Obligatoria |
+| CatalogRecord | Estado editorial | adms:status | R | R | 0..1 | 0..1 | En DCAT-AP 2.1.1 usa vocabulario [ADMS Status 1.0](http://www.w3.org/TR/vocab-adms/#status) |
+| Dataset | Nombre | dct:title | Ob | Ob | 1..n | 1..n | Sin cambios significativos |
+| Dataset | Descripción | dct:description | Ob | Ob | 1..n | 1..n | Sin cambios significativos |
+| Dataset | Publicador | dct:publisher | Ob | R | 1..1 | 0..1 | DCAT-AP-ES eleva la propiedad a Obligatoria y ajusta cardinalidad (1..1) |
+| Dataset | Temática(s) | dcat:theme | Ob | R | 1..n | 0..n | DCAT-AP-ES eleva la propiedad a Obligatoria |
+| Dataset | Distribución | dcat:distribution | R/Ob (HVD) | R | 0..n/1..n (HVD) | 0..n | DCAT-AP-ES hace obligatoria esta propiedad para conjuntos de datos HVD |
+| Dataset | Categoría HVD | dcatap:hvdCategory | Op/Ob (HVD) | No existe | 0..n/1..n (HVD) | - | Propiedad incorporada en DCAT-AP-ES desde DCAT-AP 3.0.0 |
+| Dataset | Resolución espacial | dcat:spatialResolutionInMeters | Op | R | 0..1 | 0..n | DCAT-AP-ES limita a una única resolución espacial |
+| Dataset | Resolución temporal | dcat:temporalResolution | Op | R | 0..1 | 0..n | DCAT-AP-ES limita a una única resolución temporal |
+| DataService | Nombre | dct:title | Ob | Ob | 1..n | 1..n | Sin cambios significativos |
+| DataService | URL de acceso | dcat:endpointURL | Ob | Ob | 1..n | 1..n | Sin cambios significativos |
+| DataService | Temática(s) | dcat:theme | Ob | R | 1..n | 0..n | DCAT-AP-ES eleva la propiedad a Obligatoria |
+| DataService | Publicador | dct:publisher | Ob | R | 1..1 | 0..1 | DCAT-AP-ES eleva la propiedad a Obligatoria |
+| DataService | Descripción del punto de acceso | dcat:endpointDescription | R | R | 0..n | 0..n | Sin cambios significativos |
+| DataService | Categoría HVD | dcatap:hvdCategory | Op/Ob (HVD) | No existe | 0..n/1..n (HVD) | - | Propiedad incorporada en DCAT-AP-ES desde DCAT-AP 3.0.0 |
+| Distribution | URL de acceso | dcat:accessURL | Ob | Ob | 1..n | 1..n | Sin cambios significativos |
+| Distribution | Formato | dct:format | R | R | 0..1 | 0..1 | Sin cambios significativos |
+| Distribution | Licencia | dct:license | R | R | 0..1 | 0..1 | Sin cambios significativos |
+| Distribution | Legislación aplicable | dcatap:applicableLegislation | R/Ob (HVD) | No existe | 0..n/1..n (HVD) | - | Propiedad incorporada en DCAT-AP-ES desde DCAT-AP 3.0.0 |
+| Distribution | Disponibilidad | dcatap:availability | R | No existe | 0..1 | - | Propiedad incorporada en DCAT-AP-ES desde DCAT-AP 3.0.0 |
+| Distribution | Estado | adms:status | Op | R | 0..1 | 0..1 | DCAT-AP-ES rebaja la propiedad a Opcional |
+| Distribution | Resolución espacial | dcat:spatialResolutionInMeters | Op | Op | 0..1 | 0..1 | Sin cambios significativos|
+| Distribution | Resolución temporal | dcat:temporalResolution | Op | R | 0..1 | 0..n | DCAT-AP-ES limita a una única resolución temporal |
+| Agent | Nombre | foaf:name | Ob | Ob | 1..n | 1..n | Sin cambios significativos |
+| Agent | Tipo | dct:type | R | R | 0..1 | 0..1 | Sin cambios significativos |
+| Agent | Identificador | dct:identifier | R | Op | 0..1 | 0..1 | DCAT-AP-ES eleva a Recomendado y establece formato para organismos públicos (DIR3) |
+
+## DCAT-AP 3.0.0
+
+| Entidad | Metadato | Propiedad | T | DCAT-AP<br>T | C | DCAT-AP<br>C | Observaciones |
+|---|---|---|---|---|---|---|---|
+| Catalog | Nombre | dct:title | Ob | Ob | 1..n | 1..n | Sin cambios significativos |
+| Catalog | Descripción | dct:description | Ob | Ob | 1..n | 1..n | Sin cambios significativos |
+| Catalog | Órgano publicador | dct:publisher | Ob | Ob | 1..1 | 1..1 | Sin cambios significativos |
+| Catalog | Temática(s) | dcat:themeTaxonomy | Ob | R | 1..3 | 0..n | DCAT-AP-ES requiere obligatoriamente la [taxonomía de sectores primarios](http://datos.gob.es/kos/sector-publico/sector) y restringe cardinalidad |
+| Catalog | Idioma(s) | dct:language | Ob | R | 1..n | 0..n | DCAT-AP-ES exige que al menos uno de los idiomas sea español |
+| Catalog | Fecha de creación | dct:issued | Ob | R | 1..1 | 0..1 | DCAT-AP-ES eleva la propiedad a Obligatoria |
+| Catalog | Fecha de actualización | dct:modified | Ob | R | 1..1 | 0..1 | DCAT-AP-ES eleva la propiedad a Obligatoria |
+| Catalog | Página web | foaf:homepage | Ob | R | 1..1 | 0..1 | DCAT-AP-ES eleva la propiedad a Obligatoria |
+| Catalog | Términos de uso | dct:license | Ob | R | 1..1 | 0..1 | DCAT-AP-ES eleva la propiedad a Obligatoria |
+| Catalog | Legislación aplicable | dcatap:applicableLegislation | No existe | R | - | 0..* | Propiedad de DCAT-AP 3 no incorporada a DCAT-AP-ES |
+| CatalogRecord | Estado editorial | adms:status | R | R | 0..1 | 0..1 | En DCAT-AP 3 usa vocabulario diferente al de DCAT-AP 2.1.1, en `DCAT-AP-ES` se adopta como una recomendación: `http://publications.europa.eu/resource/authority/concept-status`|
+| Dataset | Nombre | dct:title | Ob | Ob | 1..n | 1..n | Sin cambios significativos |
+| Dataset | Descripción | dct:description | Ob | Ob | 1..n | 1..n | Sin cambios significativos |
+| Dataset | Publicador | dct:publisher | Ob | R | 1..1 | 0..1 | DCAT-AP-ES eleva la propiedad a Obligatoria y ajusta cardinalidad (`1..1`) |
+| Dataset | Temática(s) | dcat:theme | Ob | R | 1..n | 0..* | DCAT-AP-ES eleva la propiedad a Obligatoria |
+| Dataset | Distribución | dcat:distribution | R/Ob (HVD) | R | 0..n/1..n (HVD) | 0..* | DCAT-AP-ES hace obligatoria esta propiedad para conjuntos de datos HVD |
+| Dataset | Categoría HVD | dcatap:hvdCategory | Op/Ob (HVD) | Op | 0..n/1..n (HVD) | 0..n | En DCAT-AP-ES es Obligatorio para conjuntos de datos HVD |
+| Dataset | Calidad | dqv:hasQualityMeasurement | No existe | Op | - | 0..n | Propiedad nueva en DCAT-AP 3.0.0 no incorporada a DCAT-AP-ES |
+| Dataset | Resolución espacial | dcat:spatialResolutionInMeters | Op | Op | 0..1 | 0..1 | DCAT-AP-ES mantiene la misma cardinalidad |
+| Dataset | Resolución temporal | dcat:temporalResolution | Op | Op | 0..1 | 0..n | DCAT-AP-ES limita a una única resolución temporal |
+| DataService | Nombre | dct:title | Ob | Ob | 1..n | 1..n | Sin cambios significativos |
+| DataService | URL de acceso | dcat:endpointURL | Ob | Ob | 1..n | 1..n | Sin cambios significativos |
+| DataService | Temática(s) | dcat:theme | Ob | R | 1..n | 0..* | DCAT-AP-ES eleva la propiedad a Obligatoria |
+| DataService | Publicador | dct:publisher | Ob | R | 1..1 | 0..1 | DCAT-AP-ES eleva la propiedad a Obligatoria |
+| DataService | Descripción del punto de acceso | dcat:endpointDescription | R | R | 0..n | 0..* | Sin cambios significativos |
+| DataService | Descripción del punto por tipo | dcat:endpointDescriptionByType | No existe | R | - | 0..n | Propiedad nueva en DCAT-AP 3.0.0 no incorporada a DCAT-AP-ES |
+| DataService | Categoría HVD | dcatap:hvdCategory | Op/Ob (HVD) | Op | 0..n/1..n (HVD) | 0..n | En DCAT-AP-ES es Obligatorio para servicios HVD |
+| Distribution | URL de acceso | dcat:accessURL | Ob | Ob | 1..n | 1..n | Sin cambios significativos |
+| Distribution | Formato | dct:format | R | R | 0..1 | 0..1 | Sin cambios significativos |
+| Distribution | Licencia | dct:license | R | R | 0..1 | 0..1 | Sin cambios significativos |
+| Distribution | Legislación aplicable | dcatap:applicableLegislation | R/Ob (HVD) | Op | 0..n/1..n (HVD) | 0..n | DCAT-AP-ES eleva a Recomendado/Obligatorio para HVD |
+| Distribution | Disponibilidad | dcatap:availability | R | R | 0..1 | 0..1 | Sin cambios significativos |
+| Distribution | Estado | adms:status | Op | Op | 0..1 | 0..1 | Sin cambios significativos  |
+| Distribution | Resolución espacial | dcat:spatialResolutionInMeters | Op | Op | 0..1 | 0..1 | Sin cambios significativos|
+| Distribution | Resolución temporal | dcat:temporalResolution | Op | Op | 0..1 | 0..1 | Sin cambios significativos |
+| Agent | Nombre | foaf:name | Ob | Ob | 1..n | 0..1 | Sin cambios significativos |
+| Agent | Tipo | dct:type | R | Op | 0..1 | 0..1 | DCAT-AP-ES eleva a Recomendado |
+| Agent | Identificador | dct:identifier | R | Op | 0..1 | 0..1 | DCAT-AP-ES eleva a Recomendado y establece formato para organismos públicos (DIR3) |
+
+
+## Extensiones
+La sección de **Extensiones** describe cómo DCAT-AP-ES amplía y adapta el modelo base de DCAT-AP para cubrir necesidades específicas del contexto español y para incorporar requisitos adicionales, como los relativos a los conjuntos de datos de alto valor (HVD). 
+
+### DCAT-AP HVD 2.2.0
+
+| Entidad | Metadato | Propiedad | T | HVD<br>T | C | HVD<br>C | Observaciones |
+|---|---|---|---|---|---|---|---|
+| Dataset | Categoría HVD | dcatap:hvdCategory | Op/Ob (HVD) | Op/Ob (HVD) | 0..n/1..n (HVD) | 0..n/1..n (HVD) | Implementación completa de DCAT-AP HVD en DCAT-AP-ES |
+| Dataset | Legislación aplicable | dcatap:applicableLegislation | R/Ob (HVD) | Op/Ob (HVD) | 0..n/1..n (HVD) | 0..n/1..n (HVD) | Implementación completa de DCAT-AP HVD en DCAT-AP-ES |
+| Dataset | Distribución | dcat:distribution | R/Ob (HVD) | Op/Ob (HVD) | 0..n/1..n (HVD) | 0..n/1..n (HVD) | Implementación completa de DCAT-AP HVD en DCAT-AP-ES |
+| Dataset | Punto de contacto | dcat:contactPoint | R/Ob (HVD) | Op/Ob (HVD) | 0..n/1..n (HVD) | 0..n/1..n (HVD) | Implementación completa de DCAT-AP HVD en DCAT-AP-ES |
+| DataService | Categoría HVD | dcatap:hvdCategory | Op/Ob (HVD) | Op/Ob (HVD) | 0..n/1..n (HVD) | 0..n/1..n (HVD) | Implementación completa de DCAT-AP HVD en DCAT-AP-ES |
+| DataService | Legislación aplicable | dcatap:applicableLegislation | R/Ob (HVD) | Op/Ob (HVD) | 0..n/1..n (HVD) | 0..n/1..n (HVD) | Implementación completa de DCAT-AP HVD en DCAT-AP-ES |
+| DataService | Punto de contacto | dcat:contactPoint | R/Ob (HVD) | Op/Ob (HVD) | 0..n/1..n (HVD) | 0..n/1..n (HVD) | Implementación completa de DCAT-AP HVD en DCAT-AP-ES |
+| DataService | Conjunto de datos servido | dcat:servesDataset | R/Ob (HVD) | Op/Ob (HVD) | 0..n/1..n (HVD) | 0..n/1..n (HVD) | Implementación completa de DCAT-AP HVD en DCAT-AP-ES |
+| Distribution | Legislación aplicable | dcatap:applicableLegislation | R/Ob (HVD) | Op/Ob (HVD) | 0..n/1..n (HVD) | 0..n/1..n (HVD) | Implementación completa de DCAT-AP HVD en DCAT-AP-ES |
+| Distribution | Licencia | dct:license | R/Ob (HVD) | Op/Ob (HVD) | 0..1/1..1 (HVD) | 0..1/1..1 (HVD) | Se mantiene la misma obligatoriedad para licencias en datos HVD |
+
+## Características distintivas de DCAT-AP-ES
+
+Este anexo presenta una visión consolidada de las diferencias principales entre DCAT-AP-ES y los perfiles europeos DCAT-AP (versiones 2.1.1 y 3.0.0), facilitando la comprensión de las particularidades del perfil español y sus requisitos específicos de implementación.
+
+### 1. Adaptación al contexto español
+- **Uso obligatorio de taxonomías nacionales**: DCAT-AP-ES exige el uso de la [taxonomía de sectores primarios](http://datos.gob.es/kos/sector-publico/sector) para clasificación temática
+- **Requisito lingüístico**: Al menos uno de los idiomas debe ser español en propiedades multilingües
+- **Normalización de identificadores organizativos**: Define URI normalizadas con formato DIR3 para organismos públicos (`http://datos.gob.es/recurso/sector-publico/org/Organismo/{ID}`)
+
+### 2. Mayor obligatoriedad en metadatos
+- DCAT-AP-ES eleva numerosas propiedades de Recomendadas a Obligatorias, especialmente en `dcat:Catalog`, `dcat:Dataset` y `dcat:DataService`
+- Define obligatoriedad para propiedades clave como `dct:publisher`, `dcat:theme` y fechas de creación/actualización
+- Adopta un enfoque más estricto para garantizar completitud e interoperabilidad de metadatos
+
+### 3. Soporte integral para datos de alto valor (HVD)
+- Integra requisitos específicos para datos de alto valor según el Reglamento de Ejecución (UE) 2023/138
+- Define propiedades obligatorias adicionales para conjuntos de datos HVD (`dcatap:hvdCategory`, `dcat:distribution`)
+- Incorpora `dcatap:applicableLegislation` como obligatoria para distribuciones HVD
+
+### 4. Evolución desde los perfiles europeos
+- Incorpora selectivamente propiedades de DCAT-AP 3.0.0 como `dcatap:availability` y `dcatap:hvdCategory`
+- Omite algunas propiedades de DCAT-AP 3.0.0 como `dqv:hasQualityMeasurement` y `dcat:endpointDescriptionByType` 
+- Actualiza vocabularios controlados (p.ej., para `adms:status` en `dcat:Distribution`)
+
+### 5. Cardinalidades adaptadas
+- Define cardinalidades más restrictivas para mayor precisión (p.ej., `dct:publisher` exige cardinalidad 1..1)
+- Limita resoluciones espaciales y temporales a una única instancia (0..1)
+- Restringe `dcat:themeTaxonomy` a máximo 3 taxonomías, incluyendo obligatoriamente la española
+
+### 6. Conformidad con marco legal
+- Implementa requisitos para cumplir con normativa española de datos abiertos (Ley 37/2007, NTI-RISP)
+- Adapta el perfil para cumplir con la Directiva (UE) 2019/1024 relativa a datos abiertos y reutilización
+- Proporciona base técnica para el cumplimiento del Real Decreto 1495/2011 y normativa relacionada
 
 [^1]: Obligatorio cuando se trata de datos de alto valor, en otro caso, recomendado.

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,25 +78,28 @@ Se enumerarán a continuación vocabularios genéricos que configuran el espacio
 | XML Schema | `xsd:` | `http://www.w3.org/2001/XMLSchema#` |
 
 ## Vocabularios controlados utilizados en el modelo {#dcat-ap-es-vocabularies}
-
-A continuación, se detalla la serie de propiedades que deben ajustarse utilizando obligatoriamente los vocabularios controlados indicados en la tabla siguiente, con el objetivo de garantizar un nivel mínimo de interoperabilidad.
+Para garantizar la coherencia e interoperabilidad entre catálogos de datos, DCAT-AP-ES recomienda el uso de vocabularios controlados para cada propiedad. La siguiente tabla muestra los vocabularios recomendados y sus correspondientes URIs, cuyo uso puede ser obligatorio en algunos casos según las especificaciones del modelo.
 
 | **Propiedad** | **Clase** | **Vocabulario** | **URI del vocabulario** |
 | --- | --- | --- | --- |
+| **adms:status** | CatalogRecord | [Concept status](https://op.europa.eu/en/web/eu-vocabularies/dataset/-/resource?uri=http://publications.europa.eu/resource/authority/concept-status) | `http://publications.europa.eu/resource/authority/concept-status` |
+| **adms:status** | Distribution | [Distribution status](https://op.europa.eu/en/web/eu-vocabularies/dataset/-/resource?uri=http://publications.europa.eu/resource/dataset/distribution-status) | `http://publications.europa.eu/resource/authority/distribution-status` |
+| **dcat:compressFormat** | Distribution | [IANA Media Types](http://www.iana.org/assignments/media-types/) | `http://www.iana.org/assignments/media-types/` |
+| **dcat:mediaType** | Distribution | [IANA Media Types](http://www.iana.org/assignments/media-types/) | `http://www.iana.org/assignments/media-types/` |
+| **dcat:packageFormat** | Distribution | [IANA Media Types](http://www.iana.org/assignments/media-types/) | `http://www.iana.org/assignments/media-types/` |
+| **dcat:theme** | Dataset<br>DataService | <ul><li>[Taxonomía de sectores primarios NTI-RISP](http://datos.gob.es/kos/sector-publico/sector)</li><li> [Vocabulario de Temas de datos (DCAT-AP)](http://publications.europa.eu/resource/authority/data-theme)</li><li>[Registro de temas INSPIRE](http://inspire.ec.europa.eu/theme)</li></ul>  | <ul><li>`http://datos.gob.es/kos/sector-publico/sector`</li><li>`http://publications.europa.eu/resource/authority/data-theme`</li><li>`http://inspire.ec.europa.eu/theme`</li></ul> |
+| **dcat:themeTaxonomy** | Catalog | <ul><li>[Taxonomía de sectores primarios NTI-RISP](http://datos.gob.es/kos/sector-publico/sector)</li><li> [Vocabulario de Temas de datos (DCAT-AP)](http://publications.europa.eu/resource/authority/data-theme)</li><li>[Registro de temas INSPIRE](http://inspire.ec.europa.eu/theme)</li></ul> | <ul><li>`http://datos.gob.es/kos/sector-publico/sector`</li><li>`http://publications.europa.eu/resource/authority/data-theme`</li><li>`http://inspire.ec.europa.eu/theme`</li></ul> |
 | **dcatap:availability** | Distribution | [Planned availability](https://op.europa.eu/en/web/eu-vocabularies/dataset/-/resource?uri=http://publications.europa.eu/resource/dataset/planned-availability) | `http://publications.europa.eu/resource/authority/planned-availability` |
+| **dcatap:hvdCategory** | Dataset<br>DataService | [HVD Category](https://op.europa.eu/web/eu-vocabularies/concept-scheme/-/resource?uri=http://data.europa.eu/bna/asd487ae75) | `http://data.europa.eu/bna/asd487ae75` |
 | **dct:accessRights** | Dataset<br>DataService | [Access right](https://op.europa.eu/en/web/eu-vocabularies/dataset/-/resource?uri=http://publications.europa.eu/resource/dataset/access-right) | `http://publications.europa.eu/resource/authority/access-right` |
 | **dct:accrualPeriodicity** | Dataset | [Frequency](https://op.europa.eu/en/web/eu-vocabularies/dataset/-/resource?uri=http://publications.europa.eu/resource/dataset/frequency) | `http://publications.europa.eu/resource/authority/frequency` |
 | **dct:format** | Distribution | [File type](https://op.europa.eu/en/web/eu-vocabularies/dataset/-/resource?uri=http://publications.europa.eu/resource/dataset/file-type) | `http://publications.europa.eu/resource/authority/file-type` |
-| **dcatap:hvdCategory** | Dataset<br>DataService | [HVD Category](https://op.europa.eu/web/eu-vocabularies/concept-scheme/-/resource?uri=http://data.europa.eu/bna/asd487ae75) | `http://data.europa.eu/bna/asd487ae75` |
-| **dct:language** | Catalog<br>Dataset<br>CatalogRecord<br>Distribution | [Language](https://op.europa.eu/en/web/eu-vocabularies/dataset/-/resource?uri=http://publications.europa.eu/resource/dataset/language) | `http://publications.europa.eu/resource/authority/language` |
+| **dct:language** | Catalog<br>Dataset<br>Distribution | [Language](https://op.europa.eu/en/web/eu-vocabularies/dataset/-/resource?uri=http://publications.europa.eu/resource/dataset/language) | `http://publications.europa.eu/resource/authority/language` |
 | **dct:license** | Catalog<br>DataService<br>Distribution | [Licence](https://op.europa.eu/en/web/eu-vocabularies/dataset/-/resource?uri=http://publications.europa.eu/resource/dataset/licence) | `http://publications.europa.eu/resource/authority/licence` |
-| **dcat:mediaType** | Distribution | [IANA Media Types](http://www.iana.org/assignments/media-types/) | `http://www.iana.org/assignments/media-types/` |
 | **dct:spatial** | Catalog<br>Dataset | <ul><li>[Taxonomía de territorio NTI-RISP](https://datos.gob.es/es/recurso/sector-publico/territorio)</li><li> [Continent](https://op.europa.eu/en/web/eu-vocabularies/dataset/-/resource?uri=http://publications.europa.eu/resource/dataset/continent)</li><li>[Countries and territories](http://op.europa.eu/en/web/eu-vocabularies/dataset/-/resource?uri=http://publications.europa.eu/resource/dataset/country)</li><li>[Administrative territorial unit](https://op.europa.eu/en/web/eu-vocabularies/dataset/-/resource?uri=http://publications.europa.eu/resource/dataset/atu)</li><li>[Place](https://op.europa.eu/en/web/eu-vocabularies/dataset/-/resource?uri=http://publications.europa.eu/resource/dataset/place)</li><li>[Geonames](http://www.geonames.org/)</li></ul> | <ul><li>`http://datos.gob.es/es/recurso/sector-publico/territorio`</li><li>`http://publications.europa.eu/resource/authority/continent`</li><li>`http://publications.europa.eu/resource/authority/country`</li><li>`http://publications.europa.eu/resource/authority/atu`</li><li>`http://publications.europa.eu/resource/authority/place`</li><li>`http://sws.geonames.org/`</li></ul> |
-| **dcat:theme** | Dataset | <ul><li>[Taxonomía de sectores primarios NTI-RISP](http://datos.gob.es/kos/sector-publico/sector)</li><li> [Vocabulario de Temas de datos (DCAT-AP)](http://publications.europa.eu/resource/authority/data-theme)</li><li>[Registro de temas INSPIRE](http://inspire.ec.europa.eu/theme)</li></ul>  | <ul><li>`http://datos.gob.es/kos/sector-publico/sector`</li><li>`http://publications.europa.eu/resource/authority/data-theme`</li><li>`http://inspire.ec.europa.eu/theme`</li></ul> |
-| **dcat:themeTaxonomy** | Catalog | <ul><li>[Taxonomía de sectores primarios NTI-RISP](http://datos.gob.es/kos/sector-publico/sector)</li><li> [Vocabulario de Temas de datos (DCAT-AP)](http://publications.europa.eu/resource/authority/data-theme)</li><li>[Registro de temas INSPIRE](http://inspire.ec.europa.eu/theme)</li></ul> | <ul><li>`http://datos.gob.es/kos/sector-publico/sector`</li><li>`http://publications.europa.eu/resource/authority/data-theme`</li><li>`http://inspire.ec.europa.eu/theme`</li></ul> |
-| **dct:type** | Agent | [Vocabulario tipo de agente organización](http://purl.org/adms/publishertype/1.0) | `http://purl.org/adms/publishertype/1.0` |
+| **dct:type** | Agent | [ADMS publisher type](http://purl.org/adms/publishertype/1.0) | `http://purl.org/adms/publishertype/1.0` |
 | **dct:type** | Dataset | [Dataset type](https://op.europa.eu/en/web/eu-vocabularies/dataset/-/resource?uri=http://publications.europa.eu/resource/dataset/dataset-type) | `http://publications.europa.eu/resource/authority/dataset-type` |
-| **adms:status** | Distribution | [Distribution status](https://op.europa.eu/en/web/eu-vocabularies/dataset/-/resource?uri=http://publications.europa.eu/resource/dataset/distribution-status) | `http://publications.europa.eu/resource/authority/distribution-status` |
+| **dct:type** | LicenseDocument | [ADMS licence type](http://purl.org/adms/licencetype/1.0) | `http://purl.org/adms/licencetype/1.0` |
 
 # Relación de metadatos del modelo DCAT-AP-ES {#dcat-ap-es-model-relations}
 
@@ -141,6 +144,7 @@ Igualmente, se indica para cada entidad del modelo -catálogo, registro, servici
 | Incluye a | Otro Catálogo que está incluido en el catálogo | dct:hasPart | Op | 0..n | **dcat:Catalog** |
 | Está incluido en | Forma parte de otro catálogo | dct:isPartOf | Op | 0..1 | **dcat:Catalog** |
 | Declaración de derechos | Declaración de los derechos relacionados con el catálogo. | dct:rights | Op | 0..1 | **dct:RightsStatement** |
+| Cobertura temporal | Define el período de tiempo que abarca el catálogo. | dct:temporal | Op | 0..n | **dct:PeriodOfTime** |
 
 
 ## Registro del catálogo - Clase: dcat:CatalogRecord - Opcional
@@ -151,6 +155,7 @@ Igualmente, se indica para cada entidad del modelo -catálogo, registro, servici
 | Fecha de última actualización | Última fecha conocida en la que se modificó o actualizó el registro del catálogo. | dct:modified | Ob | 1..1 | **rdfs:Literal** |
 | Perfil de aplicación | Marco normativo relativo al registro del catálogo. | dct:conformsTo | R | 0..1 | **dct:Standard** |
 | Fecha de creación | Fecha inicial en la que se creó el registro. | dct:issued | R | 0..1 | **rdfs:Literal** |
+| Estado | Fase del ciclo de vida en que se encuentra | adms:status | R | 0..1 | **skos:Concept** |
 | Nombre | Nombre o título del Registro del Catálogo | dct:title | Op | 0..n | **rdfs:Literal** |
 | Descripción | Descripción resumida del contenido del registro del catálogo | dct:description | Op | 0..n | **rdfs:Literal** |
 
@@ -164,12 +169,12 @@ Igualmente, se indica para cada entidad del modelo -catálogo, registro, servici
 | Punto de contacto | Información de contacto sobre el servicio de datos HVD | dcat:contactPoint | R[^1]<br>Ob (HVD) | 0..n<br>1..n (HVD) | **vcard:Kind** |
 | Documentación | Documento relevante sobre el servicio de datos HVD | foaf:page | R[^1]<br>Ob (HVD) | 0..n<br>1..n (HVD) | **foaf:Document** |
 | Temática(s) | Temática o categoría principal del servicio de datos. | dcat:theme | Ob | 1..n | **skos:Concept** |
-| Publicador | Organización que publica el servicio. | dct:publisher | Ob | 1 | **foaf:Agent** |
+| Publicador | Organización que publica el servicio. | dct:publisher | Ob | 1..1 | **foaf:Agent** |
 | Descripción del punto de acceso | Descripción de las características del punto de acceso | dcat:endpointDescription | R | 0..n | **rdfs:Resource** |
 | Conjuntos de datos | Conjuntos de datos disponibles a través del servicio. | dcat:servesDataset | R[^1]<br>Ob (HVD) | 0..n<br>1..n (HVD) | **dcat:Dataset** |
 | Legislación aplicable | URI de la legislación que es aplicable al recurso | dcatap:applicableLegislation | R[^1]<br>Ob (HVD) | 0..n<br>1..n (HVD) | **eli:LegalResource** |
 | Descripción | Descripción resumida del servicio de datos | dct:description | Op | 0..n | **rdfs:Literal** |
-| Derechos de acceso | Declaración acerca de las posibles restricciones de acceso | dct:accessRights | Op | 0..1 | **RightsStatement** |
+| Derechos de acceso | Declaración acerca de las posibles restricciones de acceso | dct:accessRights | Op | 0..1 | **dct:RightsStatement** |
 | Licencia | Licencia del Servicio de datos | dct:license | Op | 0..1 | **dct:LicenseDocument** |
 | Etiqueta(s) | Etiqueta(s) textual(es) para categorizar libremente el servicio de datos. | dcat:keyword | Op | 0..n | **rdfs:Literal** |
 
@@ -235,7 +240,7 @@ Igualmente, se indica para cada entidad del modelo -catálogo, registro, servici
 | Esquema | Esquema o modelo de datos vinculado | dct:conformsTo | Op | 0..n | **dct:Standard** |
 | Fecha de creación de la distribución | Fecha de creación | dct:issued | Op | 0..1 | **rdfs:Literal** |
 | Fecha de última actualización de la distribución | Última fecha conocida en la que se actualizó la distribución | dct:modified | Op | 0..1 | **rdfs:Literal** |
-| Estado | Fase del ciclo de vida en que se encuentra | adms:status | Op | 0..1 | **skos:Concept** |
+| Estado | Estado del registro de catálogo en el contexto del flujo editorial de las descripciones de conjuntos de datos y servicios de datos. | adms:status | Op | 0..1 | **skos:Concept** |
 | Idioma(s) | Idioma(s) empleado en la información contenida en la distribución | dct:language | Op | 0..n | **dct:LinguisticSystem** |
 | Formato comprimido | Formato de compresión en el que se encuentran los datos | dcat:compressFormat | Op | 0..1 | **dct:MediaType** |
 | Formato empaquetado | Formato en el que agrupan archivos para su descarga | dcat:packageFormat | Op | 0..1 | **dct:MediaType** |
@@ -483,14 +488,14 @@ Se describe mediante las siguientes propiedades:
     2.  Como alternativa, es posible delimitar el área geográfica utilizando las propiedades de la clase [Location](#loca) (explicada más adelante en este documento).
 
 
-| dcat:Catalog | dct:catalog |
+| dcat:Catalog | dcat:catalog |
 | --- | --- |
 | **Metadato** | **Catálogo** |
 | **Descripción** | Especifica un catálogo de datos que es relevante o de interés en relación con el catálogo actual. |
-| **Propiedad** | **dct:catalog** |
+| **Propiedad** | **dcat:catalog** |
 | **Aplicabilidad** | **Opcional** |
 | **Cardinalidad** | **0..n** |
-| **Rango** | **dct:Catalog** |
+| **Rango** | **dcat:Catalog** |
 
 !!! note "Nota de uso"
 
@@ -504,7 +509,7 @@ Se describe mediante las siguientes propiedades:
 | **Propiedad** | **dcat:record** |
 | **Aplicabilidad** | **Opcional** |
 | **Cardinalidad** | **0..n** |
-| **Rango** | **dct:CatalogRecord** |
+| **Rango** | **dcat:CatalogRecord** |
 
 !!! note "Nota de uso"
 
@@ -566,6 +571,18 @@ Se describe mediante las siguientes propiedades:
 
     Mediante esta declaración se especifican los derechos que no están cubiertos por los términos de uso (`dct:licence`) o los derechos de acceso (`dct:accessRights`), por ejemplo, derechos de propiedad intelectual. Para ajustar esta propiedad se pueden utilizar propiedades del vocabulario `http://schema.theodi.org/odrs/`
 
+| dcat:DataseCatalogt | dct:temporal |
+| --- | --- |
+| **Metadato** | **Cobertura temporal** |
+| **Descripción** | Define el período de tiempo que abarca el catálogo. |
+| **Propiedad** | **dct:temporal** |
+| **Aplicabilidad** | **Opcional** |
+| **Cardinalidad** | **0..n** |
+| **Rango** | **dct:PeriodOfTime** |
+
+!!! note "Nota de uso"
+
+    Se ajusta utilizando las propiedades de la clase Período temporal (`dct:PeriodOfTime`). Se recomienda incluir un intervalo de tiempo, definido por inicio y fin como fecha o instante temporal. Si se usa fecha para el inicio, debería usarse fecha como fin (ídem para instante temporal) y siempre emparejados, evitando los intervalos abiertos.
 
 ## Metadatos de la clase Registro del Catálogo {#dcat-catalogrecord}
 
@@ -630,6 +647,18 @@ Si esta función no es necesaria, la clase `dcat:CatalogRecord` se puede ignor
 
     Se puede registrar la fecha utilizando el formato estándar: `YYYY-MM-DD` (`xsd:date`), o el [datetime ISO-8601](https://www.w3.org/TR/1998/NOTE-datetime-19980827) con zona horaria: `YYYY-MM-DDThh:mm:ssTZD` (`xsd:dateTime`), así como el año: `YYYY` (`xsd:gYear`) o el año y el mes: `YYYY-MM` (`xsd:gYearMonth`).
 
+| dcat:CatalogRecord | adms:status |
+| --- | --- |
+| **Metadato** | **Estado editorial del registro** |
+| **Descripción** | Estado del registro de catálogo en el contexto del flujo editorial de las descripciones de conjuntos de datos y servicios de datos. |
+| **Propiedad** | **adms:status** |
+| **Aplicabilidad** | **Recomendado** |
+| **Cardinalidad** | **0..1** |
+| **Rango** | **skos:Concept** |
+
+!!! note "Nota de uso"
+
+    El estado del registro del catálogo puede ser alguno de los valores definidos en el vocabulario:  `http://publications.europa.eu/resource/authority/concept-status` ([Recomendación DCAT 3](https://www.w3.org/TR/vocab-dcat-3/#life-cycle))
 
 | dcat:CatalogRecord | dct:title |
 | --- | --- |
@@ -808,7 +837,7 @@ Utilizando esta clase, un dataset se puede distribuir en diferentes representaci
       * respuesta OGC GetCapabilities ([WFS](http://www.opengeospatial.org/standards/wfs)) o ([WMS](http://www.opengeospatial.org/standards/wms)).
       * descripción del servicio [SPARQL](https://www.w3.org/TR/sparql11-service-description/)
     
-    2. documento [OpenSearch](https://github.com/dewitt/opensearch/blob/master/opensearch-1-1-draft-6.md), [WSDL 2.0](https://www.w3.org/TR/wsdl20/) o descripción de la API [Hydra](https://www.hydra-cg.com/spec/latest/core/)u otras alternativas autodescriptivas legibles por máquina.
+    2. documento [OpenSearch](https://github.com/dewitt/opensearch/blob/master/opensearch-1-1-draft-6.md), [WSDL 2.0](https://www.w3.org/TR/wsdl20/) o descripción de la API [Hydra](https://www.hydra-cg.com/spec/latest/core/) u otras alternativas autodescriptivas legibles por máquina.
     
     3. un recurso web que referencie un documento en formato texto o algún otro modo informal.
 
@@ -848,7 +877,7 @@ Utilizando esta clase, un dataset se puede distribuir en diferentes representaci
 | **Propiedad** | **dct:accessRights** |
 | **Aplicabilidad** | **Opcional** |
 | **Cardinalidad** | **0..1** |
-| **Rango** | **RightsStatement** |
+| **Rango** | **dct:RightsStatement** |
 
 !!! note "Nota de uso"
 
@@ -1257,7 +1286,7 @@ Esta clase es una de las clases fundamentales en repositorios y catálogos, ya q
 | **Aplicabilidad** | **Opcional** |
 | **Cardinalidad** | **0..n** |
 | **Rango** | **rdfs:Literal** |
-
+****
 !!! note "Nota de uso"
 
     Se recomienda que se detallen las diferencias con la versión inmediatamente anterior. Puede incluirse esta descripción en varios idiomas.
@@ -1368,7 +1397,7 @@ Esta clase es una de las clases fundamentales en repositorios y catálogos, ya q
 | **Propiedad** | **dct:relation** |
 | **Aplicabilidad** | **Opcional** |
 | **Cardinalidad** | **0..n** |
-| **Rango** | **Rdfs:Resource** |
+| **Rango** | **rdfs:Resource** |
 
 !!! note "Nota de uso"
 
@@ -1386,7 +1415,7 @@ Esta clase es una de las clases fundamentales en repositorios y catálogos, ya q
 
 !!! note "Nota de uso"
 
-    Se debe utilizar cuando la naturaleza de la relación entre Agente y conjunto de datos es conocida, pero no encaja con ninguno de los roles específicos (dct:creator, dct:publisher). Se recomienda utilizar además la propiedad dcat:hadRole para especificar la responsabilidad del Agente respecto al recurso.
+    Se debe utilizar cuando la naturaleza de la relación entre Agente y conjunto de datos es conocida, pero no encaja con ninguno de los roles específicos (`dct:creator`, `dct:publisher`). Se recomienda utilizar además la propiedad `dcat:hadRole` para especificar la responsabilidad del Agente respecto al recurso.
 
 
 | dcat:Dataset | prov:wasGeneratedBy |
@@ -1647,10 +1676,10 @@ Esta entidad se considera clave para entender cómo se puede obtener y utilizar 
 
 !!! note "Nota de uso"
 
-    El estado de la distribución de un conjunto de datos puede ser alguno de los siguientes: completa, obsoleta, en desarrollo o retirada. Estos valores están definidos en el vocabulario:  `http://publications.europa.eu/resource/authority/distribution-status`
+    El estado de la distribución de un conjunto de datos puede ser alguno de los siguientes: `completa`, `obsoleta`, `en desarrollo` o `retirada`. Estos valores están definidos en el vocabulario:  `http://publications.europa.eu/resource/authority/distribution-status`
 
 
-| dcat:Distribution | adms:language |
+| dcat:Distribution | dct:language |
 | --- | --- |
 | **Metadato** | **Idioma** |
 | **Descripción** | Especifica el idioma en el que se encuentra la información contenida en la distribución del conjunto de datos. |
@@ -1820,7 +1849,7 @@ Como se indica a continuación, todo agente o entidad debe tener un nombre y es 
 | foaf:Agent | dct:type |
 | --- | --- |
 | **Metadato** | **Tipo** |
-| **Descripción** | Permite identificar la categoría de entidad en la que se enmarca el agente |
+| **Descripción** | Permite identificar la categoría de entidad en la que se enmarca el agente. |
 | **Propiedad** | **dct:type** |
 | **Aplicabilidad** | **Recomendado** |
 | **Cardinalidad** | **0..1** |
@@ -1860,7 +1889,7 @@ La clase Control y Verificación de recursos de datos (`spdx:Checksum`) se utili
 
 !!! note "Nota de uso"
 
-    El valor del resultado de verificación debe ser único y exactoy se debe expresar codificado en formato hexadecimal.
+    El valor del resultado de verificación debe ser único, exacto y se debe expresar codificado en formato hexadecimal.
 
 
 ## Metadatos de la clase Localización {#dct-location}
@@ -1884,7 +1913,7 @@ Para su implementación, se pueden utilizar las siguientes propiedades recomenda
 
 !!! note "Nota de uso"
 
-    El rango de esta propiedad es genérico (`rdfs:Literal`) para poder expresar la geometría utilizando diferentes codificaciones. Por ejemplo, se puede expresar indicando las coordenadas geográficas (Longitud y Latitud) de las cuatro esquenas que delimitan el rectángulo geográfico.
+    El rango de esta propiedad es genérico (`rdfs:Literal`) para poder expresar la geometría utilizando diferentes codificaciones. Por ejemplo, se puede expresar indicando las coordenadas geográficas (Longitud y Latitud) de las cuatro esquinas que delimitan el rectángulo geográfico.
 
 
 | dct:Location | dcat:centroid |
@@ -1981,7 +2010,7 @@ Respecto al uso de las propiedades fecha de inicio (`dcat:startDate`) y fecha de
 
 !!! note "Nota de uso"
 
-    Se recomienda proporcionar el momento específico de comienzo del período temporal expresando un valor tipificado con alguna de las propiedades que proporciona la [ontología Time](https://www.w3.org/TR/owl-time/#time:Instant) para definir un instante concreto de una línea temporal: 
+    Se recomienda proporcionar el momento específico de finalización del período temporal expresando un valor tipificado con alguna de las propiedades que proporciona la [ontología Time](https://www.w3.org/TR/owl-time/#time:Instant) para definir un instante concreto de una línea temporal: 
     
     * [time:inXSDDate](https://www.w3.org/TR/owl-time/#time:inXSDDate)
     * [time::inXSDDateTimeStamp](https://www.w3.org/TR/owl-time/#time:inXSDDateTimeStamp)
@@ -2026,8 +2055,84 @@ Se utilizan dos propiedades (`dct:relation` y `dcat:hadRole`) que se declaran ob
 
     Se debe especificar la referencia a un recurso de datos ([`dcat:Dataset`](#conjunto-de-datos---clase-dcatdataset---obligatorio) o [`dcat:DataService`](#servicio-de-datos---clase-dcatdataservice---opcional)).
 
+Aquí tienes una actualización para la sección de **Documento de licencia** (`dct:LicenseDocument`) siguiendo la referencia de DCAT-AP 3 (sección 7.11):
 
-# Anexo 1. Cambios del modelo DCAT-AP-ES respecto a NTI-RISP (v.2013) {#annex-1-nti-risp-to-dcat-ap-es}
+## Metadatos de la clase Documento de licencia {#dct-licencedocument}
+
+La clase **Documento de licencia** (`dct:LicenseDocument`) representa un documento legal que otorga permiso oficial para hacer algo con un recurso, como reutilizar, compartir o modificar datos.
+
+Se utiliza para describir las condiciones legales bajo las cuales se puede utilizar un recurso, proporcionando claridad sobre los derechos y obligaciones asociados.
+
+| dct:LicenseDocument | dct:type |
+| --- | --- |
+| **Metadato** | **Tipo** |
+| **Descripción** | Permite identificar el tipo de licencia en el que se enmarca el documento. |
+| **Propiedad** | **dct:type** |
+| **Aplicabilidad** | **Recomendado** |
+| **Cardinalidad** | **0..1** |
+| **Rango** | **skos:Concept** |
+
+!!! note "Nota de uso"
+
+    Se deben utilizar vocabularios controlados o esquemas de clasificación estandarizados para describir el tipo de documento de licencia. Se recomienda el uso del vocabulario `http://purl.org/adms/licencetype/1.0`
+
+# Conformidad
+
+## DCAT-AP
+
+DCAT-AP-ES se basa en DCAT-AP 2.1.1, se alinea con las principales restricciones.
+
+## DCAT-AP-ES
+
+### Requisitos del publicador de datos
+
+Un publicador de datos es conforme con DCAT-AP-ES cuando:
+
+1. **Implementación de clases obligatorias**: Implementa todas las clases y propiedades propiedades obligatorias definidas por el modelo.
+
+2. **Coherencia semántica**: Mantiene la coherencia en las descripciones y relaciones entre entidades, asegurando que los metadatos proporcionan una representación precisa y consistente de los recursos. Esto incluye:
+   - Uso apropiado de las propiedades según su definición semántica
+   - Consistencia entre los valores de las propiedades relacionadas
+   - Evitar contradicciones o redundancias en los metadatos
+   - Asegurar que las referencias entre recursos son válidas y significativas
+
+3. **Vocabularios controlados**: Utiliza los vocabularios controlados especificados en la sección Vocabularios controlados utilizados en el modelo para todas las propiedades que lo requieran, especialmente aquellas marcadas como obligatorias.
+
+4. **Datos de Alto Valor (HVD)**: Para conjuntos de datos clasificados como HVD, implementa las propiedades adicionales obligatorias para HVD marcadas en el documento.
+
+### Requisitos del catálogo de datos
+
+Un catálogo de datos es conforme con DCAT-AP-ES cuando:
+
+1. **Estructura del catálogo**: Se estructura como una instancia de `dcat:Catalog` que contiene o referencia todas las instancias de `dcat:Dataset` y/o `dcat:DataService`.
+
+2. **Propiedades obligatorias del catálogo**: Implementa todas las propiedades obligatorias de la clase `dcat:Catalog`:
+   - `dct:title`: Nombre del catálogo
+   - `dct:description`: Descripción del catálogo 
+   - `dct:publisher`: Entidad responsable de publicar el catálogo
+   - `foaf:homepage`: URL de acceso público al catálogo
+   - `dcat:themeTaxonomy`: Al menos una taxonomía de sectores primarios
+   - `dct:issued`: Fecha de publicación inicial
+   - `dct:modified`: Fecha de última modificación
+   - `dct:language`: Idioma(s) del catálogo (incluyendo español)
+   - `dct:license`: Términos de uso del catálogo
+
+3. **Vocabularios controlados**: Utiliza los vocabularios controlados específicos para propiedades como `dcat:themeTaxonomy` (obligatoriamente la taxonomía de sectores primarios de datos.gob.es), `dct:language` (usando el vocabulario autorizado de la UE), entre otros.
+
+4. **Federación**: Es capaz de compartir sus metadatos con el catálogo nacional datos.gob.es a través de alguno de los mecanismos de federación soportados (SPARQL endpoint, API, volcado RDF, etc.).
+
+5. **Recursos clasificados**: Todos los datasets y servicios dentro del catálogo están correctamente clasificados según las taxonomías de sectores primarios y otros vocabularios controlados.
+
+6. **Consistencia y validación**: Todos los recursos del catálogo cumplen con los requisitos estructurales y semánticos del modelo DCAT-AP-ES, y pueden ser validados mediante herramientas de validación DCAT-AP.
+
+7. **Metadatos de calidad**: Para los conjuntos de datos de alto valor (HVD), el catálogo proporciona todos los metadatos adicionales obligatorios según la normativa HVD, incluyendo la legislación aplicable y la categoría HVD correspondiente.
+
+8. **Recursos accesibles**: Todas las distribuciones referenciadas en el catálogo son accesibles a través de las URLs proporcionadas, o se indica claramente cuando no lo son mediante las propiedades de disponibilidad y estado apropiadas.
+
+La conformidad con estos requisitos asegura la interoperabilidad del catálogo con la Iniciativa Nacional de Datos Abiertos y facilita la federación con datos.gob.es y el Portal Europeo de Datos.
+
+
+# Anexo 1. Cambios del modelo DCAT-AP-ES respecto del modelo NTI-RISP (v.2013) {#annex-1-nti-risp-to-dcat-ap-es}
 
 A continuación, se detalla la relación de cambios y actualizaciones en los metadatos del modelo DCAT-AP-ES respecto al [modelo de metadatos NTI-RISP (v. 2013)](https://datosgobes.github.io/NTI-RISP), así como la relación de metadatos que han sido deprecados.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2362,8 +2362,82 @@ Este anexo presenta una visión consolidada de las diferencias principales entre
 - Restringe `dcat:themeTaxonomy` a máximo 3 taxonomías, incluyendo obligatoriamente la española
 
 ### 6. Conformidad con marco legal
-- Implementa requisitos para cumplir con normativa española de datos abiertos (Ley 37/2007, NTI-RISP)
-- Adapta el perfil para cumplir con la Directiva (UE) 2019/1024 relativa a datos abiertos y reutilización
-- Proporciona base técnica para el cumplimiento del Real Decreto 1495/2011 y normativa relacionada
+- Implementa requisitos para cumplir con normativa española de datos abiertos ([Ley 37/2007, de 16 de noviembre, sobre reutilización de la información del sector público](https://www.boe.es/eli/es/l/2007/11/16/37/con), [Resolución de 19 de febrero de 2013, de la Secretaría de Estado de Administraciones Públicas, por la que se aprueba la Norma Técnica de Interoperabilidad de Reutilización de recursos de la información](https://www.boe.es/eli/es/res/2013/02/19/(4)))
+- Adapta el perfil para cumplir con la [Directiva (UE) 2019/1024](http://data.europa.eu/eli/dir/2019/1024/oj) relativa a datos abiertos y reutilización.
+
+# Histórico de cambios
+
+Este apartado proporciona una visión general de los cambios incorporados en DCAT-AP-ES. Una lista completa de las incidencias cerradas con esta versión está accesible en [GitHub](https://github.com/datosgobes/DCAT-AP-ES/issues).
+
+## DCAT-AP-ES 1.0.0
+
+### Cambios principales
+
+- Transformación del documento PDF en representación HTML (estilo [RESPEC](https://respec.org/docs/) usando [MkDocs](https://www.mkdocs.org/) + [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/)
+- Integración de directrices y textos actualizados relacionados con DCAT-AP-ES
+- Actualización y mejora de referencias cruzadas para facilitar la navegación
+- Corrección de numerosas erratas y problemas de conversión
+- Actualización del reconocimiento a los colaboradores
+
+### Adaptaciones a las diferentes secciones
+- **Introducción**: Revisión para reflejar el contexto actual y los fundamentos del perfil
+- **Conformidad**: Actualización para reflejar los requisitos de implementación en el ecosistema español
+- **Terminología**: Lista de prefijos actualizada con los vocabularios más recientes
+- **Modelo de datos**: Estructura reorganizada para mejorar la legibilidad
+- **Vocabularios controlados**: Actualización de referencias a vocabularios autorizados
+- **Conjuntos de datos de alto valor (HVD)**: Integración completa de los requisitos del [Reglamento de Ejecución (UE) 2023/138](http://data.europa.eu/eli/reg_impl/2023/138/oj)
+- **Anexo de referencia rápida**: Generación automática desde el modelo de datos para mantener sincronización
+
+#### Cambios respecto a NTI-RISP
+
+- Actualización completa de las clases y propiedades conforme a DCAT-AP
+- Eliminación de propiedades obsoletas y reemplazo por alternativas más adecuadas
+- Reestructuración para adaptarse a los nuevos requisitos de la [Directiva (UE) 2019/1024](http://data.europa.eu/eli/dir/2019/1024/oj)
+- Implementación de metadatos específicos para conjuntos de datos de alto valor (HVD)
+- Ampliación de capacidades para describir servicios de datos (APIs y endpoints)
+
+#### Diferencias con DCAT-AP
+
+- Mayor nivel de obligatoriedad en propiedades clave para garantizar calidad de metadatos
+- Adaptación al marco normativo español y sus requisitos específicos
+- Cardinalidades más restrictivas para garantizar uniformidad y precisión
+- Requisitos lingüísticos específicos del contexto multilingüe español
+- Integración con sistemas de identificación de organismos públicos españoles (DIR3)
+
+### Adaptaciones del modelo de datos
+
+La lista siguiente indica los cambios y diferencias respecto a la versión anterior (NTI-RISP). También se incluye el impacto de la alineación con W3C DCAT y DCAT-AP europeo.
+
+- División de los textos descriptivos existentes en definiciones y notas de uso siguiendo las mejores prácticas de SEMIC
+- Alineación con DCAT-AP 2.1.1 y adopción selectiva de elementos de DCAT-AP 3.0.0
+- Organización del perfil en Entidades Principales, Entidades de Soporte y Tipos de Datos
+- Elevación de numerosas propiedades a obligatorias para garantizar interoperabilidad
+- Incorporación de aspectos específicos para datos de alto valor (HVD)
+- Adaptación a requisitos lingüísticos y de clasificación territorial de España
+
+### Requisitos específicos para el contexto español
+
+- **Taxonomías nacionales**: Implementación obligatoria de la taxonomía de sectores primarios española
+- **Requisito lingüístico**: Obligatoriedad del español como uno de los idiomas en propiedades multilingües
+- **Identificadores normalizados**: Adopción del esquema DIR3 para la identificación de organismos públicos
+
+### Alineación con HVD (Datos de Alto Valor)
+
+- Integración completa de los requisitos del Reglamento de Ejecución (UE) 2023/138
+- Definición clara de propiedades obligatorias adicionales para conjuntos de datos HVD
+- Incorporación de metadatos para la trazabilidad y cumplimiento normativo (legislación aplicable, categorías HVD)
+
+### SHACL y validación
+
+- Desarrollo de reglas SHACL para validación automática del perfil
+- Inclusión de identificadores únicos para cada restricción
+- Implementación de pruebas para verificar conformidad con el perfil
+
+### Correcciones de errores
+
+- Alineación de propiedades con su definición en los vocabularios originales
+- Corrección de cardinalidades para reflejar requisitos específicos del contexto español
+- Mejora de las descripciones y notas de uso para facilitar la implementación correcta
+- Ajustes en referencias a vocabularios controlados para asegurar su disponibilidad y persistencia
 
 [^1]: Obligatorio cuando se trata de datos de alto valor, en otro caso, recomendado.

--- a/docs/validation.en.md
+++ b/docs/validation.en.md
@@ -1,6 +1,8 @@
-![](img/dge_shacl.en.drawio "Ilustración . Description of SHACL validation steps"){ align=center width="100%"}
-
 To verify that the metadata exchange is technically compliant with [DCAT-AP-EN](/), the [SHACL shapes available in the repository](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/) graphs can be used. Shapes Constraint Language* (SHACL) is a [W3C recommendation](https://www.w3.org/TR/shacl/]) for expressing constraints in an RDF knowledge graph. 
+
+The following illustration schematically shows the main stages of the SHACL validation process applied to metadata, from data preparation to obtaining the conformance results.
+
+![](img/dge_shacl.en.drawio "Ilustración . Description of SHACL validation steps"){ align=center width="100%"}
 
 SHACL shapes allow checking whether a catalog expressed in an RDF serialization is valid. Since it should be possible to transform the data exchange to RDF for DCAT-AP-ES compliance, these SHACL forms can be used in any data exchange context. However, the provided SHACL forms are only a starting point for implementers.
 

--- a/docs/validation.en.md
+++ b/docs/validation.en.md
@@ -25,12 +25,12 @@ DCAT-AP-ES SHACL shapes for all versions can be found in the source code reposit
 - `shacl_imports.ttl`: Import definitions for external ontologies
 - `shacl_mdr_imports.ttl`: Import definitions for MDR vocabularies
 
-`hvd/`: Subdirectory with additional constraints for High Value Datasets (HVD): - `shacl_common_hvd_shapes.ttl`: Common constraints for all entities.
+**`hvd/`**: Subdirectory with additional constraints for High Value Datasets (HVD): - `shacl_common_hvd_shapes.ttl`: Common constraints for all entities.
 
-- `shacl_catalog_shape.ttl`: Constraints for catalogs
-- `shacl_dataservice_hvd_shape.ttl`: Constraints for Data Services
-- `shacl_dataset_hvd_shape.ttl`: Constraints for datasets
-- `shacl_distribution_hvd_shape.ttl`: Constraints for distributions
+- `shacl_catalog_shape.ttl`: Constraints for HVD catalogues.
+- `shacl_dataservice_hvd_shape.ttl`: Constraints for HVD Data Services.
+- `shacl_dataset_hvd_shape.ttl`: Constraints for HVD datasets.
+- `shacl_distribution_hvd_shape.ttl`: Constraints for HVD distributions.
 
 # Use Cases
 *Non-normative section*
@@ -95,6 +95,17 @@ Extends [Case 1](validation/#case_1_dcat_ap_en_full) with background knowledge a
 - *Imports*
   - [`shacl_imports.ttl`](https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/1.0.0/shacl_imports.ttl)
   - [`shacl_mdr_imports.ttl`](https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/1.0.0/shacl_mdr_imports.ttl)
+
+!!! info "What is background knowledge?"
+    Background knowledge consists of importing external ontologies and vocabularies that complement the validation. These import files (`shacl_imports.ttl` and `shacl_mdr_imports.ttl`) contain definitions of classes, properties, and hierarchical relationships from the standards used in DCAT-AP-ES.
+    
+    Using this background knowledge allows:
+    
+    1. *Semantically richer validations*: By knowing the complete structure of the ontologies.
+    2. *Type inference*: Enables detection of inconsistencies in the class hierarchy.
+    3. *Derived property validation*: Checks relationships that might not be explicit in the data.
+    
+    However, including this background knowledge can make validation slower and more resource-intensive.
 
 ## **Caso 4: Full DCAT-AP-ES (HVD with background knowlegdge)** {#case_4_dcat_ap_es_full_hvd_imports}
 Extends [Case 1](validation/#case_1_dcat_ap_en_full) with background knowledge about conformance to external standards. It also includes the forms that allow to properly describe high value datasets ([HVD](#high_value_datasets_high_value_datasets)).

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -16,23 +16,23 @@ Al utilizar estas plantillas es posible identificar y corregir posibles desviaci
 # Formas SHACL de DCAT-AP-ES
 Todas las versiones de los ficheros de formas de DCAT-AP-ES se encuentran en el repositorio de código [`shacl/{version}/`](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/): 
 
-- `shacl_common_shapes.ttl`: Restricciones comunes para todas las entidades
-- `shacl_catalog_shape.ttl:` Restricciones para catálogos
-- `shacl_dataservice_shape.ttl`: Restricciones para servicios de datos
-- `shacl_dataset_shape.ttl`: Restricciones para conjuntos de datos
-- `shacl_distribution_shape.ttl`: Restricciones para distribuciones
-- `shacl_dataservice_shape.ttl`: Restricciones para servicios de datos
-- `shacl_mdr-vocabularies.shape.ttl`: Vocabularios controlados y sus restricciones
-- `shacl_imports.ttl`: Definiciones de importación para ontologías externas
-- `shacl_mdr_imports.ttl`: Definiciones de importación para vocabularios MDR
+- `shacl_common_shapes.ttl`: Restricciones comunes para todas las entidades.
+- `shacl_catalog_shape.ttl:` Restricciones para catálogos.
+- `shacl_dataservice_shape.ttl`: Restricciones para servicios de datos.
+- `shacl_dataset_shape.ttl`: Restricciones para conjuntos de datos.
+- `shacl_distribution_shape.ttl`: Restricciones para distribuciones.
+- `shacl_dataservice_shape.ttl`: Restricciones para servicios de datos.
+- `shacl_mdr-vocabularies.shape.ttl`: Vocabularios controlados y sus restricciones.
+- `shacl_imports.ttl`: Definiciones de importación para ontologías externas.
+- `shacl_mdr_imports.ttl`: Definiciones de importación para vocabularios MDR.
 
-`hvd/`: Subdirectorio con restricciones adicionales para conjuntos de datos de alto valor (HVD):
+**`hvd/`**: Subdirectorio con restricciones adicionales para conjuntos de datos de alto valor (HVD):
 
-- `shacl_common_hvd_shapes.ttl`: Restricciones comunes para todas las entidades
-- `shacl_catalog_shape.ttl:` Restricciones para catálogos
-- `shacl_dataservice_hvd_shape.ttl`: Restricciones para servicios de datos
-- `shacl_dataset_hvd_shape.ttl`: Restricciones para conjuntos de datos
-- `shacl_distribution_hvd_shape.ttl`: Restricciones para distribuciones
+- `shacl_common_hvd_shapes.ttl`: Restricciones comunes para todas las entidades HVD.
+- `shacl_catalog_shape.ttl:` Restricciones para catálogos HVD.
+- `shacl_dataservice_hvd_shape.ttl`: Restricciones para servicios de datos HVD.
+- `shacl_dataset_hvd_shape.ttl`: Restricciones para conjuntos de datos HVD.
+- `shacl_distribution_hvd_shape.ttl`: Restricciones para distribuciones HVD.
 
 # Casos de Uso
 *Sección no normativa*
@@ -96,6 +96,17 @@ Extiende el [Caso 1](validation/#case_1_dcat_ap_es_full) con conocimiento de fon
 - *Importaciones*
   - [`shacl_imports.ttl`](https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/shacl_imports.ttl)
   - [`shacl_mdr_imports.ttl`](https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/shacl_mdr_imports.ttl)
+
+!!! info "¿Qué es el conocimiento de fondo?"
+    El conocimiento de fondo (*background knowledge*) consiste en la importación de ontologías y vocabularios externos que complementan la validación. Estos archivos de importación (`shacl_imports.ttl` y `shacl_mdr_imports.ttl`) contienen definiciones de clases, propiedades y relaciones jerárquicas de los estándares utilizados en DCAT-AP-ES.
+    
+    Utilizar este conocimiento de fondo permite:
+    
+    1. *Validaciones semánticamente más ricas*: Al conocer la estructura completa de las ontologías.
+    2. *Inferencia de tipos*: Permite detectar inconsistencias en la jerarquía de clases.
+    3. *Validación de propiedades derivadas*: Comprueba relaciones que podrían no estar explícitas en los datos.
+    
+    Sin embargo, incluir este conocimiento de fondo puede hacer que la validación sea más lenta y consuma más recursos.
 
 ## **Caso 4: DCAT-AP-ES completo (HVD con conocimiento de fondo)** {#case_4_dcat_ap_es_full_hvd_imports}
 Extiende el [Caso 1](validation/#case_1_dcat_ap_es_full) con conocimiento de fondo conformidad con estándares externos. También incluye las formas que permiten describir adecuadamente los conjuntos de datos de alto valor ([HVD](#conjuntos_de_datos_de_alto_valor_high_value_datasets)).

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,6 +1,8 @@
-![](img/dge_shacl.es.drawio "Ilustración . Descripción de los pasos de validación SHACL")
+Con el propósito de verificar si el intercambio de metadatos cumple técnicamente con [DCAT-AP-ES](/), se pueden utilizar los grafos de [formas SHACL disponibles en el repositorio](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/). El Lenguaje de Restricción de Formas (*Shapes Constraint Language* - SHACL), es una [recomendación del W3C](https://www.w3.org/TR/shacl/]) para expresar restricciones en un grafo de conocimiento RDF. 
 
-Para verificar si el intercambio de metadatos cumple técnicamente con [DCAT-AP-ES](/), se pueden utilizar los grafos de [formas SHACL disponibles en el repositorio](https://github.com/datosgobes/DCAT-AP-ES/tree/main/shacl/). El Lenguaje de Restricción de Formas (*Shapes Constraint Language* - SHACL), es una [recomendación del W3C](https://www.w3.org/TR/shacl/]) para expresar restricciones en un grafo de conocimiento RDF. 
+La siguiente ilustración muestra de forma esquemática las etapas principales del proceso de validación SHACL aplicadas a los metadatos, desde la preparación de los datos hasta la obtención de los resultados de conformidad.
+
+![](img/dge_shacl.es.drawio "Ilustración . Descripción de los pasos de validación SHACL")
 
 Las formas SHACL permiten comprobar si un catálogo expresado en una serialización RDF es válido. Dado que debería ser posible transformar el intercambio de datos en RDF para la conformidad con DCAT-AP-ES, estas formas SHACL pueden utilizarse en cualquier contexto de intercambio de datos. Sin embargo las formas SHACL proporcionadas son solo un punto de partida para los implementadores.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,7 +17,7 @@ nav:
   - Convenciones datos.gob.es: conventions.md
   - FAQ: faq.md
   - Validación: validation.md
-  - Ejemplos: examples.md
+  - Ejemplos de implementación: examples.md
 
 theme:
   language: es
@@ -45,8 +45,6 @@ theme:
     - navigation.expand
     - navigation.footer
     - navigation.indexes
-    - navigation.instant
-    - navigation.instant.progress
     - navigation.prune
     - search.suggest
     - search.highlight
@@ -169,11 +167,11 @@ plugins:
           name: English
           build: true
           nav:
-          - DCAT-AP-ES technical guide: index.md
-          - datos.gob.es conventions: conventions.en.md
+          - DCAT-AP-ES Technical Guide: index.md
+          - datos.gob.es Conventions: conventions.en.md
           - FAQ: faq.en.md
           - Validation: validation.en.md
-          - Examples: examples.en.md
+          - Implementation Examples: examples.en.md
   - mkdocstrings:
       handlers:
         python:
@@ -278,6 +276,13 @@ dcatapes:
     owners:
       - name: Iniciativa de datos abiertos del Gobierno de España
         link: 'https://datos.gob.es/'
+    period:
+      start:
+        value: "Pendiente de publicación"
+        title: "Fecha de entrada en vigor de DCAT-AP-ES"
+      # end:
+      #   value: "Vigente" 
+      #   title: "Fecha de descontinuación o vigencia"
     categories:
       latest_published_version: Última versión publicada
       latest_editors_draft: Último borrador del editor
@@ -286,6 +291,7 @@ dcatapes:
       author: Autor
       feedback: Retroalimentación
       owners: Propietarios
+      period: "Período de vigencia"
     copyright:
       name: CC BY 4.0
       link: https://creativecommons.org/licenses/by/4.0/
@@ -419,6 +425,13 @@ dcatapes:
     owners:
       - name: Spanish Government Open Data Initiative
         link: 'https://datos.gob.es/'
+    period:
+      start:
+        value: "Pending publication"
+        title: "Effective date of DCAT-AP-ES"
+      # end:
+      #   value: "Valid"
+      #   title: "End of life or effective date"
     categories:
       latest_published_version: Latest Published Version
       latest_editors_draft: Latest Editor's Draft
@@ -427,6 +440,7 @@ dcatapes:
       author: Author
       feedback: Feedback
       owners: Owners
+      period: "Period of validity"
     copyright:
       name: CC BY 4.0
       link: https://creativecommons.org/licenses/by/4.0/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -226,8 +226,9 @@ watch:
 - refs/docs
 
 exclude_docs: |
-    !/refs/*
-    !/README.md
+    /refs/*
+    /README.md
+    /**/README.md
 
 hooks:
   - tools/mkdocs-hooks/dcat_ap_es.py

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -236,7 +236,7 @@ hooks:
 dcatapes:
   # Spanish
   es:
-    draft: false
+    draft: true
     download_pdf: false
     title: Guía técnica de implementación del perfil de aplicación DCAT-AP-ES de acuerdo a la NTI-RISP
     base_url: 'https://github.com/datosgobes/DCAT-AP-ES'
@@ -347,7 +347,8 @@ dcatapes:
         text: "Disponible también en formato"
     buttons:
       draft_label: 
-        label: Borrador
+        label: "Pendiente de publicación"
+        tooltip: "Esta versión está pendiente de publicación oficial y puede no ser la versión final"
       download_pdf:
         enabled: true
         title: Descargar como PDF
@@ -486,7 +487,8 @@ dcatapes:
         text: "Also available in"
     buttons:
       draft_label: 
-        label: Draft
+        label: "To be published"
+        tooltip: "This version is pending official publication and may not be the final version"
       download_pdf:
         enabled: true
         title: Download as PDF

--- a/overrides/dcatapes/conventions_header.html
+++ b/overrides/dcatapes/conventions_header.html
@@ -1,8 +1,5 @@
 {% set lang = config.theme.language if config.theme.language in config.dcatapes else config.dcatapes.keys()|list|first %}
 <div class="head" id="index_header">
-    {% if config.dcatapes[lang].conventions.draft %}
-        <div class="draft-label">{{ config.dcatapes[lang].buttons.draft_label.label }}</div>
-    {% endif %}
     <div class="download-button-container">
         {% if config.dcatapes[lang].conventions.download_pdf %}
         <a class="md-content__button md-icon" href="{{ config.dcatapes[lang].buttons.download_pdf.href.conventions }}" title="{{ config.dcatapes[lang].buttons.download_pdf.title }}" target="_blank" rel="noopener noreferrer">

--- a/overrides/dcatapes/header_warning.html
+++ b/overrides/dcatapes/header_warning.html
@@ -1,0 +1,15 @@
+{% if config.extra.warning_banner %}
+  <div class="warning-banner">
+    <span class="twemoji warning-icon">
+      {% include ".icons/material/fire.svg" %}
+    </span>
+    
+    {% if config.theme.language and config.theme.language == 'en' and config.extra.warning_banner.en %}
+      {{ config.extra.warning_banner.en | safe }}
+    {% elif config.extra.warning_banner.es %}
+      {{ config.extra.warning_banner.es | safe }}
+    {% else %}
+      {{ config.extra.warning_banner | safe }}
+    {% endif %}
+  </div>
+{% endif %}

--- a/overrides/dcatapes/index_header.html
+++ b/overrides/dcatapes/index_header.html
@@ -1,8 +1,5 @@
 {% set lang = config.theme.language if config.theme.language in config.dcatapes else config.dcatapes.keys()|list|first %}
 <div class="head" id="index_header">
-    {% if config.dcatapes[lang].draft %}
-        <div class="draft-label">{{ config.dcatapes[lang].buttons.draft_label.label }}</div>
-    {% endif %}
     <div class="download-button-container">
         {% if config.dcatapes[lang].download_pdf %}
         <a class="md-content__button md-icon" href="{{ config.dcatapes[lang].buttons.download_pdf.href.index }}" title="{{ config.dcatapes[lang].buttons.download_pdf.title }}" target="_blank" rel="noopener noreferrer">

--- a/overrides/dcatapes/index_header.html
+++ b/overrides/dcatapes/index_header.html
@@ -84,6 +84,25 @@
                     {% endif %}
                 </dd>
             {% endfor %}
+            <!--Entrada en vigor - Descontinuación -->
+            {% if config.dcatapes[lang].period and (config.dcatapes[lang].period.start.value or config.dcatapes[lang].period.end.value) %}
+              <dt>{{ config.dcatapes[lang].categories.period }}:</dt>
+              <dd>
+                {% if config.dcatapes[lang].period.start.value %}
+                  <span class="period-start tooltip" title="{{ config.dcatapes[lang].period.start.title }}">
+                    {{ config.dcatapes[lang].period.start.value }}
+                  </span>
+                {% endif %}
+                {% if config.dcatapes[lang].period.start.value and period_end_value %}
+                  &nbsp;–&nbsp;
+                {% endif %}
+                {% if period_end_value %}
+                  <span class="period-end tooltip" title="{{ period_end.title }}">
+                    {{ period_end_value }}
+                  </span>
+                {% endif %}
+              </dd>
+            {% endif %}
         </dl>
         {% if config.dcatapes[lang].also_available and config.dcatapes[lang].also_available.enabled %}
             <div class="also-available-container">

--- a/overrides/dcatapes/jsonld/faq.json
+++ b/overrides/dcatapes/jsonld/faq.json
@@ -68,7 +68,7 @@
             "inLanguage": "es",
             "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "Los publicadores disponen de un periodo de adaptación de seis meses desde la entrada en vigor de la NTI-RISP.",
+                "text": "Los publicadores disponen de un periodo de adaptación desde la entrada en vigor de la NTI-RISP.",
                 "inLanguage": "es"
             }
         },

--- a/overrides/dcatapes/jsonld/faq.json
+++ b/overrides/dcatapes/jsonld/faq.json
@@ -301,6 +301,46 @@
                 "text": "The e-Government Portal (PAe) provides more information and documentation support for the Technical Interoperability Standards (TSI) published in the BOE.",
                 "inLanguage": "en"
             }
+        },
+        {
+            "@type": "Question",
+            "name": "¿Cómo evoluciono desde un catálogo NTI-RISP a DCAT-AP-ES?",
+            "inLanguage": "es",
+            "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "Si ya tienes un catálogo conforme al modelo de metadatos NTI-RISP 2013, para evolucionar a DCAT-AP-ES puedes: 1. Identificar cambios y añadir nuevos metadatos obligatorios. 2. Adaptar vocabularios controlados. 3. Añadir soporte a servicios. 4. Validar el catálogo con las herramientas proporcionadas.",
+                "inLanguage": "es"
+            }
+        },
+        {
+            "@type": "Question",
+            "name": "How do I evolve from an NTI-RISP catalog to DCAT-AP-ES?",
+            "inLanguage": "en",
+            "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "If you already have a catalog that conforms to the 2013 NTI-RISP metadata model, to evolve to DCAT-AP-ES you can: 1. Identify changes and add new mandatory metadata. 2. Adapt controlled vocabularies. 3. Add support for services. 4. Validate the catalog with the provided tools.",
+                "inLanguage": "en"
+            }
+        },
+        {
+            "@type": "Question",
+            "name": "¿Cuáles son las diferencias entre DCAT-AP-ES y DCAT-AP?",
+            "inLanguage": "es",
+            "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "DCAT-AP-ES añade mayor obligatoriedad en ciertas propiedades, incorpora requisitos específicos del contexto español como taxonomías propias, integra completamente el modelo de datos de alto valor (HVD), y limita algunas cardinalidades para descripciones más precisas.",
+                "inLanguage": "es"
+            }
+        },
+        {
+            "@type": "Question",
+            "name": "What are the differences between DCAT-AP-ES and DCAT-AP?",
+            "inLanguage": "en",
+            "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "DCAT-AP-ES adds greater mandatory requirements for certain properties, incorporates specific requirements of the Spanish context such as specific taxonomies, fully integrates the high-value dataset model (HVD), and limits some cardinalities for more precise descriptions.",
+                "inLanguage": "en"
+            }
         }
     ]
 }

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -35,6 +35,7 @@
 
 {% block container %}
 
+  <!--Draft ribbon-->
   {% if config.dcatapes[lang_code].draft %}
     <div class="draft-ribbon" title="{{ config.dcatapes[lang_code].buttons.draft_label.tooltip }}">
       {{ config.dcatapes[lang_code].buttons.draft_label.label }}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-
+{% set lang_code = config.theme.language if config.theme.language in config.dcatapes else config.dcatapes.keys()|list|first %}
 {% set ns = namespace(index_page_title='', conventions_page_title='', faq_page_title='') %}
 {% for item in config.nav %}
     {% for key, value in item.items() %}
@@ -34,6 +34,13 @@
 {% endblock %}
 
 {% block container %}
+
+  {% if config.dcatapes[lang_code].draft %}
+    <div class="draft-ribbon" title="{{ config.dcatapes[lang_code].buttons.draft_label.tooltip }}">
+      {{ config.dcatapes[lang_code].buttons.draft_label.label }}
+    </div>
+  {% endif %}
+
   <div class="md-content" data-md-component="content">
     <article class="md-content__inner md-typeset">
       <!-- Include the content of index_header.html only if it is index or conventions -->

--- a/overrides/partials/header.html
+++ b/overrides/partials/header.html
@@ -30,6 +30,12 @@
 
 <!-- Header -->
 <header class="{{ class }}" data-md-component="header">
+  
+  <!-- Global warning Banner -->
+  {% block warning_header %}
+    {% include "dcatapes/header_warning.html" %}
+  {% endblock %}
+
   <nav
     class="md-header__inner md-grid"
     aria-label="{{ lang.t('header') }}"
@@ -53,19 +59,16 @@
     </label>
 
     <!-- Header title -->
-    <div class="md-header__title" data-md-component="header-title">
+    <div class="md-header__title">
       <div class="md-header__ellipsis">
         <div class="md-header__topic">
           <span class="md-ellipsis">
-            {{ config.site_name }}
-          </span>
-        </div>
-        <div class="md-header__topic" data-md-component="header-topic">
-          <span class="md-ellipsis">
             {% if page.meta and page.meta.title %}
-              {{ page.meta.title }}
+              {{ config.site_name }}: {{ page.meta.title }}
+            {% elif page.title %}
+              {{ config.site_name }}: {{ page.title }}
             {% else %}
-              {{ page.title }}
+              {{ config.site_name }}
             {% endif %}
           </span>
         </div>

--- a/shacl/1.0.0/hvd/shacl_common_hvd_shapes.ttl
+++ b/shacl/1.0.0/hvd/shacl_common_hvd_shapes.ttl
@@ -1,0 +1,47 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix : <http://datos.gob.es/dcat-ap-es#> .
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcatapes: <https://datosgobes.github.io/DCAT-AP-ES/> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+
+<https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/hvd/shacl_common_hvd_shapes.ttl>
+    rdf:type owl:Ontology ;
+    rdfs:label "Restricciones comunes para HVD en DCAT-AP-ES"@es ;
+    rdfs:label "Common restrictions for HVD in DCAT-AP-ES"@en ;
+    dcat:downloadURL <https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/hvd/shacl_common_hvd_shapes.ttl> ;
+    dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE> ;
+    dct:conformsTo <https://www.w3.org/TR/shacl> ;
+    dct:description "Este archivo incluye restricciones SHACL comunes específicas para datos de alto valor (HVD) utilizadas en el perfil de aplicación DCAT-AP-ES."@es ;
+    dct:description "This file includes common SHACL restrictions specific to High-Value Datasets (HVD) used in the DCAT-AP-ES application profile."@en ;
+    owl:versionInfo "1.0.0" ;
+    dct:modified "2025-04-10"^^xsd:date ;
+    dct:publisher <http://datos.gob.es/recurso/sector-publico/org/Organismo/E0DAT0001> ;
+    cc:attributionURL <https://datos.gob.es/> ;
+    dcatap:availability <http://data.europa.eu/r5r/stable> ;
+    foaf:homepage <https://datosgobes.github.io/DCAT-AP-ES/> ;
+    rdfs:comment """
+        Este archivo incluye restricciones SHACL comunes específicas para validar propiedades y clases relacionadas con datos de alto valor (Reglamento de ejecución (UE) 2023/138 de la Comisión Europea (High Value Datasets Implementing Regulation, HVD IR)) en el perfil DCAT-AP-ES. 
+        Actualmente, este archivo sirve como base para futuras extensiones y puede ser importado junto con otros archivos dependientes.
+    """@es ;
+    rdfs:comment """
+        This file includes common SHACL restrictions specific to validating properties and classes related to High-Value Datasets (High Value Datasets Implementing Regulation, HVD IR 2023/138) in the DCAT-AP-ES profile. 
+        Currently, this file serves as a foundation for future extensions and can be imported along with other dependent files.
+    """@en .
+
+
+#--------------------------
+# Common for HVD restrictions
+#--------------------------
+:HVDCategory_HVDRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Shape reservado para futuras restricciones específicas de categorías HVD."@es ;
+    rdfs:comment "Shape reserved for future specific restrictions on HVD categories."@en ;
+    rdfs:label "Restricción para categoría HVD (vacía)"@es ;
+    rdfs:label "HVD Category Restriction (empty)"@en .

--- a/shacl/1.0.0/hvd/shacl_dataservice_hvd_shape.ttl
+++ b/shacl/1.0.0/hvd/shacl_dataservice_hvd_shape.ttl
@@ -1,0 +1,164 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix : <http://datos.gob.es/dcat-ap-es#> .
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcatapes: <https://datosgobes.github.io/DCAT-AP-ES/> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+
+<https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/1.0.0/hvd/shacl_dataservice_hvd_shape.ttl>
+    rdf:type owl:Ontology ;
+    rdfs:label "Restricciones para los servicios de datos HVD en DCAT-AP-ES"@es ;
+    rdfs:label "Data service restrictions for HVD in DCAT-AP-ES"@en ;
+    dcat:downloadURL <https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/1.0.0/hvd/shacl_dataservice_hvd_shape.ttl> ;
+    dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE> ;
+    dct:conformsTo <https://www.w3.org/TR/shacl> ;
+    dct:description "Este archivo incluye las restricciones SHACL específicas para servicios de datos de alto valor (HVD) para las propiedades y clases relacionadas con servicios de datos en el perfil de aplicación DCAT-AP-ES."@es ;
+    dct:description "This file includes SHACL restrictions specific to High-Value Data Services (HVD) for properties and classes related to data services in the DCAT-AP-ES application profile."@en ;
+    owl:versionInfo "1.0.0" ;
+    dct:modified "2024-04-08"^^xsd:date ;
+    dct:publisher <http://datos.gob.es/recurso/sector-publico/org/Organismo/E0DAT0001> ;
+    cc:attributionURL <https://datos.gob.es/> ;
+    dcatap:availability <http://data.europa.eu/r5r/stable> ;
+    foaf:homepage <https://datosgobes.github.io/DCAT-AP-ES/> ;
+    rdfs:seeAlso <https://datosgobes.github.io/DCAT-AP-ES/#dcat-dataservice>  ;
+    rdfs:comment """
+        Este archivo requiere importar las siguientes dependencias adicionales para funcionar correctamente de acuerdo con el Reglamento de ejecución (UE) 2023/138 de la Comisión Europea (High Value Datasets Implementing Regulation, HVD IR):
+        - shacl_common_hvd_shape.ttl
+        - shacl_common_shapes.ttl
+        - shacl_mdr-vocabularies.shape.ttl
+        Asegúrese de que estén disponibles e importadas para una validación completa.
+    """@es ;
+    rdfs:comment """
+        This file requires importing the following additional dependencies to work properly according to the Implementing Regulation (EU) 2023/138 of the European Commission (High Value Datasets Implementing Regulation, HVD IR 2023/138):
+        - shacl_common_hvd_shape.ttl
+        - shacl_common_shapes.ttl
+        - shacl_mdr-vocabularies.shape.ttl
+        Make sure they are available and imported for full validation.
+    """@en .
+
+
+#--------------------------
+# dcat:DataService HVD restrictions
+#--------------------------
+# Convencion 12
+:DataService_HVD_Shape
+    a sh:NodeShape ;
+    sh:name "Servicio de Datos HVD"@en ;
+    sh:name "HVD Data Service"@en ;
+    rdfs:comment "Forma que define las restricciones para la clase dcat:DataService de acuerdo con las especificaciones para datos de alto valor (HVD). Ver: https://datosgobes.github.io/DCAT-AP-ES/#convencion-12"@es ;
+    rdfs:comment "Shape that defines the restrictions for the dcat:DataService class according to the specifications for High-Value Datasets (HVD). See: https://datosgobes.github.io/DCAT-AP-ES/#convencion-12"@en ;
+    rdfs:label "Restricciones de servicio de datos HVD"@es ;
+    rdfs:label "HVD data service restrictions"@en ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#convencion-12> ;
+    sh:closed false ;
+    sh:property
+    [ 
+    # dcatap:hvdCategory
+        sh:path dcatap:hvdCategory;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcatap_hvdcategory> ;
+        sh:message "El valor de dcatap:hvdCategory debe ser un IRI válido."@es ;
+        sh:message "The value of dcatap:hvdCategory must be a valid IRI."@en ;
+    ],
+    [
+        sh:path dcatap:hvdCategory;
+        sh:node :HVDCategoryRestriction ;
+    ],
+
+    # dcat:contactPoint
+    [
+        sh:path dcat:contactPoint ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcat_contactpoint> ;
+        sh:message "El servicio de datos HVD debe contener al menos un dcat:contactPoint."@es ;
+        sh:message "The HVD data service must contain at least one dcat:contactPoint."@en ;
+    ], 
+
+    # dcat:servesDataset
+    [
+        sh:path dcat:servesDataset ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcat_servesdataset> ;
+        sh:message "El servicio de datos HVD debe contener al menos un dcat:servesDataset."@es ;
+        sh:message "The HVD data service must contain at least one dcat:servesDataset."@en ;
+    ],
+    
+    # dcatap:applicableLegislation
+    [
+        sh:path dcatap:applicableLegislation ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcatap_applicablelegislation> ;
+        sh:message "El valor de dcatap:applicableLegislation debe ser un IRI válido."@es ;
+        sh:message "The value of dcatap:applicableLegislation must be a valid IRI."@en ;
+    ],
+    [
+        sh:path dcatap:applicableLegislation ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcatap_applicablelegislation> ;
+        sh:message "El servicio de datos debería contener al menos un dcatap:applicableLegislation."@es ;
+        sh:message "The data service should contain at least one dcatap:applicableLegislation."@en ;
+    ], 
+    [
+        sh:path dcatap:applicableLegislation;
+        sh:name "applicable legislation"@en;
+        sh:description "The applicable legislation must be set to the HVD IR ELI."@en;
+        sh:hasValue <http://data.europa.eu/eli/reg_impl/2023/138/oj> ;
+        sh:severity sh:Violation;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcatap_applicablelegislation> ;
+        sh:message "El servicio de datos HVD debe contener un dcatap:applicableLegislation cuyo valor sea el ELI del Reglamento de ejecución HVD: <http://data.europa.eu/eli/reg_impl/2023/138/oj>."@es ;
+        sh:message "The HVD data service must contain a dcatap:applicableLegislation whose value is the ELI of the HVD Implementing Regulation: <http://data.europa.eu/eli/reg_impl/2023/138/oj>."@en ;
+    ], 
+
+    # dcatap:hvdCategory
+    [
+        sh:path dcatap:hvdCategory;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcatap_hvdcategory> ;
+        sh:message "El valor de dcatap:hvdCategory debe ser un IRI válido."@es ;
+        sh:message "The value of dcatap:hvdCategory must be a valid IRI."@en ;
+    ],
+    [
+        sh:path dcatap:hvdCategory ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcatap_hvdcategory> ;
+        sh:message "El servicio de datos HVD debe contener al menos un dcatap:hvdCategory."@es ;
+        sh:message "The HVD data service must contain at least one dcatap:hvdCategory."@en ;
+    ], 
+    [
+        sh:path dcatap:hvdCategory;
+        sh:node :HVDCategoryRestriction ;
+        sh:severity sh:Violation ;
+    ],
+
+    # foaf:page
+    [
+        sh:path foaf:page ;
+        sh:nodeKind sh:IRI;
+        #sh:class foaf:Document ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-foaf_page> ;
+        sh:message "El valor de foaf:page debe ser un IRI válido."@es ;
+        sh:message "The value of foaf:page must be a valid IRI."@en ;
+    ], 
+    [
+        sh:path foaf:page ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-foaf_page> ;
+        sh:message "El servicio de datos HVD debe contener al menos un foaf:page."@es ;
+        sh:message "The HVD data service must contain at least one foaf:page."@en ;
+    ];
+    sh:targetClass dcat:DataService .

--- a/shacl/1.0.0/hvd/shacl_dataset_hvd_shape.ttl
+++ b/shacl/1.0.0/hvd/shacl_dataset_hvd_shape.ttl
@@ -1,0 +1,116 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix : <http://datos.gob.es/dcat-ap-es#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcatapes: <https://datosgobes.github.io/DCAT-AP-ES/> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+
+<https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/shacl_dataset_shape.ttl>
+    rdf:type owl:Ontology ;
+    rdfs:label "Restricciones para los conjuntos de datos HVD DCAT-AP-ES"@es ;
+    rdfs:label "Dataset restrictions for HVD in DCAT-AP-ES"@en ;
+    dcat:downloadURL <https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/shacl_dataset_shape.ttl> ;
+    dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE> ;
+    dct:conformsTo <https://www.w3.org/TR/shacl> ;
+    dct:description "Este archivo incluye las restricciones SHACL para las propiedades y clases relacionadas con conjuntos de datos de alto valor (HVD) en el perfil de aplicación DCAT-AP-ES."@es ;
+    dct:description "This file includes SHACL restrictions for properties and classes related to High-Value Data datasets (HVD) in the DCAT-AP-ES application profile."@en ;
+    owl:versionInfo "1.0.0" ;
+    dct:modified "2024-04-08"^^xsd:date ;
+    dct:publisher <http://datos.gob.es/recurso/sector-publico/org/Organismo/E0DAT0001> ;
+    cc:attributionURL <https://datos.gob.es/> ;
+    dcatap:availability <http://data.europa.eu/r5r/stable> ;
+    foaf:homepage <https://datosgobes.github.io/DCAT-AP-ES/> ;
+    rdfs:seeAlso <https://datosgobes.github.io/DCAT-AP-ES/#dcat-dataset> ;
+    rdfs:comment """
+        Este archivo requiere importar las siguientes dependencias adicionales para funcionar correctamente:
+        - shacl_common_hvd_shape.ttl
+        - shacl_common_shapes.ttl
+        - shacl_mdr-vocabularies.shape.ttl
+        - shacl_distribution_shape.ttl
+        Asegúrese de que estén disponibles e importadas para una validación completa.
+    """@es ;
+    rdfs:comment """
+        This file requires importing the following additional dependencies to work properly:
+        - shacl_common_hvd_shape.ttl
+        - shacl_common_shapes.ttl
+        - shacl_mdr-vocabularies.shape.ttl
+        - shacl_distribution_shape.ttl
+        Make sure they are available and imported for full validation.
+    """@en .
+
+
+#--------------------------
+# dcat:Dataset HVD restrictions
+#--------------------------
+:Dataset_HVD_Shape
+    a sh:NodeShape ;
+    sh:name "Conjunto de datos HVD"@en ;
+    sh:name "HVD Dataset"@en ;
+    rdfs:comment "Forma que define las restricciones para la clase dcat:Dataset HVD."@es ;
+    rdfs:comment "Shape defining restrictions for the HVD dcat:Dataset class."@en ;
+    rdfs:label "Restricciones de conjunto de datos HVD"@es ;
+    rdfs:label "HVD dataset restrictions"@en ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#dcat-dataset> ;
+    sh:property 
+    [
+    # dcatap:applicableLegislation
+        sh:path dcatap:applicableLegislation ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dcatap_applicablelegislation> ;
+        sh:message "El valor de dcatap:applicableLegislation debe ser un IRI válido."@es ;
+        sh:message "The value of dcatap:applicableLegislation must be a valid IRI."@en ;
+    ],
+    [
+        sh:path dcatap:applicableLegislation ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dcatap_applicablelegislation> ;
+        sh:message "El servicio de datos debería contener al menos un dcatap:applicableLegislation."@es ;
+        sh:message "The data service should contain at least one dcatap:applicableLegislation."@en ;
+    ], 
+    [
+        sh:path dcatap:applicableLegislation;
+        sh:name "applicable legislation"@en;
+        sh:description "The applicable legislation must be set to the HVD IR ELI."@en;
+        sh:hasValue <http://data.europa.eu/eli/reg_impl/2023/138/oj> ;
+        sh:severity sh:Violation;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dcatap_applicablelegislation> ;
+        sh:message "El servicio de datos HVD debe contener un dcatap:applicableLegislation cuyo valor sea el ELI del Reglamento de ejecución HVD: <http://data.europa.eu/eli/reg_impl/2023/138/oj>."@es ;
+        sh:message "The HVD data service must contain a dcatap:applicableLegislation whose value is the ELI of the HVD Implementing Regulation: <http://data.europa.eu/eli/reg_impl/2023/138/oj>."@en ;
+    ], 
+
+    # dcatap:hvdCategory
+    [
+        sh:path dcatap:hvdCategory;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dcatap_hvdcategory> ;
+        sh:message "El valor de dcatap:hvdCategory debe ser un IRI válido."@es ;
+        sh:message "The value of dcatap:hvdCategory must be a valid IRI."@en ;
+    ],
+    [
+        sh:path dcatap:hvdCategory;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dcatap_hvdcategory> ;
+        sh:message "El conjunto de datos HVD debe contener al menos un dcatap:hvdCategory."@es ;
+        sh:message "The HVD dataset must contain at least one dcatap:hvdCategory."@en ;
+    ],
+    [
+        sh:path dcatap:hvdCategory ;
+        sh:node :HVDCategoryRestriction ;
+    ];
+    sh:targetClass dcat:Dataset .

--- a/shacl/1.0.0/hvd/shacl_dataset_hvd_shape.ttl
+++ b/shacl/1.0.0/hvd/shacl_dataset_hvd_shape.ttl
@@ -17,11 +17,11 @@
 @prefix dcatapes: <https://datosgobes.github.io/DCAT-AP-ES/> .
 @prefix dcatap: <http://data.europa.eu/r5r/> .
 
-<https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/shacl_dataset_shape.ttl>
+<https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/hvd/shacl_dataset_hvd_shape.ttl>
     rdf:type owl:Ontology ;
     rdfs:label "Restricciones para los conjuntos de datos HVD DCAT-AP-ES"@es ;
     rdfs:label "Dataset restrictions for HVD in DCAT-AP-ES"@en ;
-    dcat:downloadURL <https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/shacl_dataset_shape.ttl> ;
+    dcat:downloadURL <https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/hvd/shacl_dataset_hvd_shape.ttl> ;
     dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE> ;
     dct:conformsTo <https://www.w3.org/TR/shacl> ;
     dct:description "Este archivo incluye las restricciones SHACL para las propiedades y clases relacionadas con conjuntos de datos de alto valor (HVD) en el perfil de aplicación DCAT-AP-ES."@es ;

--- a/shacl/1.0.0/hvd/shacl_distribution_hvd_shape.ttl
+++ b/shacl/1.0.0/hvd/shacl_distribution_hvd_shape.ttl
@@ -1,0 +1,87 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix : <http://datos.gob.es/dcat-ap-es#> .
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcatapes: <https://datosgobes.github.io/DCAT-AP-ES/> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+
+<https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/1.0.0/hvd/shacl_distribution_hvd_shape.ttl>
+    rdf:type owl:Ontology ;
+    rdfs:label "Restricciones para las distribuciones HVD en DCAT-AP-ES"@es ;
+    rdfs:label "Distribution restrictions for HVD in DCAT-AP-ES"@en ;
+    dcat:downloadURL <https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/1.0.0/hvd/shacl_distribution_hvd_shape.ttl> ;
+    dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE> ;
+    dct:conformsTo <https://www.w3.org/TR/shacl> ;
+    dct:description "Este archivo incluye las restricciones SHACL específicas para distribuciones de datos de alto valor (HVD) para las propiedades y clases relacionadas con distribuciones en el perfil de aplicación DCAT-AP-ES."@es ;
+    dct:description "This file includes SHACL restrictions specific to High-Value Data distributions (HVD) for properties and classes related to distributions in the DCAT-AP-ES application profile."@en ;
+    owl:versionInfo "1.0.0" ;
+    dct:modified "2024-04-08"^^xsd:date ;
+    dct:publisher <http://datos.gob.es/recurso/sector-publico/org/Organismo/E0DAT0001> ;
+    cc:attributionURL <https://datos.gob.es/> ;
+    dcatap:availability <http://data.europa.eu/r5r/stable> ;
+    foaf:homepage <https://datosgobes.github.io/DCAT-AP-ES/> ;
+    rdfs:seeAlso <https://datosgobes.github.io/DCAT-AP-ES/#dcat-distribution>  ;
+    rdfs:comment """
+        Este archivo requiere importar las siguientes dependencias adicionales para funcionar correctamente de acuerdo con el Reglamento de ejecución (UE) 2023/138 de la Comisión Europea (High Value Datasets Implementing Regulation, HVD IR):
+        - shacl_common_hvd_shape.ttl
+        - shacl_common_shapes.ttl
+        - shacl_mdr-vocabularies.shape.ttl
+        Asegúrese de que estén disponibles e importadas para una validación completa.
+    """@es ;
+    rdfs:comment """
+        This file requires importing the following additional dependencies to work properly according to the Implementing Regulation (EU) 2023/138 of the European Commission (High Value Datasets Implementing Regulation, HVD IR 2023/138):
+        - shacl_common_hvd_shape.ttl
+        - shacl_common_shapes.ttl
+        - shacl_mdr-vocabularies.shape.ttl
+        Make sure they are available and imported for full validation.
+    """@en .
+
+
+#--------------------------
+# dcat:Distribution HVD restrictions
+#--------------------------
+:Distribution_HVD_Shape
+    a sh:NodeShape ;
+    sh:name "Distribución HVD"@en ;
+    sh:name "HVD Distribution"@en ;
+    rdfs:comment "Forma que define las restricciones para la clase dcat:Distribution e acuerdo con las especificaciones para datos de alto valor (HVD)."@es ;
+    rdfs:comment "Shape that defines the restrictions for the dcat:Distribution class according to the specifications for High-Value Datasets (HVD)."@en ;
+    rdfs:label "Restricciones de distribución HVD"@es ;
+    rdfs:label "HVD distribution restrictions"@en ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#dcat-distribution> ;
+    sh:closed false ;
+    sh:property
+    [
+    # dcatap:applicableLegislation
+        sh:path dcatap:applicableLegislation ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dcatap_applicablelegislation> ;
+        sh:message "El valor de dcatap:applicableLegislation debe ser un IRI válido."@es ;
+        sh:message "The value of dcatap:applicableLegislation must be a valid IRI."@en ;
+    ],
+    [
+        sh:path dcatap:applicableLegislation ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dcatap_applicablelegislation> ;
+        sh:message "La distribución HVD debería contener al menos un dcatap:applicableLegislation."@es ;
+        sh:message "The HVD distribution should contain at least one dcatap:applicableLegislation."@en ;
+    ], 
+    [
+        sh:path dcatap:applicableLegislation;
+        sh:name "applicable legislation"@en;
+        sh:description "The applicable legislation must be set to the HVD IR ELI."@en;
+        sh:hasValue <http://data.europa.eu/eli/reg_impl/2023/138/oj> ;
+        sh:severity sh:Violation;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dcatap_applicablelegislation> ;
+        sh:message "La distribución HVD debe contener un dcatap:applicableLegislation cuyo valor sea el ELI del Reglamento de ejecución HVD: <http://data.europa.eu/eli/reg_impl/2023/138/oj>."@es ;
+        sh:message "The HVD distribution must contain a dcatap:applicableLegislation whose value is the ELI of the HVD Implementing Regulation: <http://data.europa.eu/eli/reg_impl/2023/138/oj>."@en ;
+    ];
+    sh:targetClass dcat:Distribution .

--- a/shacl/1.0.0/shacl_catalog_shape.ttl
+++ b/shacl/1.0.0/shacl_catalog_shape.ttl
@@ -1,0 +1,495 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix : <https://datosgobes.github.io/DCAT-AP-ES/> .
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcatapes: <https://datosgobes.github.io/DCAT-AP-ES/> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+
+<https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/shacl_catalog_shape.ttl>
+    rdf:type owl:Ontology ;
+    rdfs:label "Restricciones para los catálogos de datos DCAT-AP-ES"@es ;
+    rdfs:label "Data catalogue restrictions for DCAT-AP-ES"@en ;
+    dcat:downloadURL <https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/shacl_distribution_shape.ttl> ;
+    dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE> ;
+    dct:conformsTo <https://www.w3.org/TR/shacl> ;
+    dct:description "Este archivo incluye las restricciones SHACL para las propiedades y clases relacionadas con catálogos de datos en el perfil de aplicación DCAT-AP-ES."@es ;
+    dct:description "This file includes SHACL restrictions for properties and classes related to data catalogues in the DCAT-AP-ES application profile."@en ;
+    owl:versionInfo "1.0.0" ;
+    dct:modified "2024-04-08"^^xsd:date ;
+    dct:publisher <http://datos.gob.es/recurso/sector-publico/org/Organismo/E0DAT0001> ;
+    cc:attributionURL <https://datos.gob.es/> ;
+    dcatap:availability <http://data.europa.eu/r5r/stable> ;
+    foaf:homepage <https://datosgobes.github.io/DCAT-AP-ES/> ;
+    rdfs:seeAlso <https://datosgobes.github.io/DCAT-AP-ES/#dcat-catalog> ;
+    rdfs:comment """
+        Este archivo requiere importar las siguientes dependencias adicionales para funcionar correctamente:
+        - shacl_common_shapes.ttl
+        - shacl_mdr-vocabularies.shape.ttl
+        Asegúrese de que estén disponibles e importadas para una validación completa.
+    """@es ;
+    rdfs:comment """
+        This file requires importing the following additional dependencies to work properly:
+        - shacl_common_shapes.ttl
+        - shacl_mdr-vocabularies.shape.ttl
+        Make sure they are available and imported for full validation.
+    """@en .
+
+
+#--------------------------
+# dcat:Catalog restrictions
+#--------------------------
+:Catalog_Shape
+    a sh:NodeShape ;
+    sh:name "Catálogo"@en ;
+    sh:name "Catalog"@en ;
+    rdfs:comment "Forma que define las restricciones para la clase dcat:Catalog."@es ;
+    rdfs:comment "Shape defining restrictions for the dcat:Catalog class."@en ;
+    rdfs:label "Restricciones de catálogo de datos"@es ;
+    rdfs:label "Catalog restrictions"@en ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#dcat-catalog> ;
+    sh:property 
+    [
+    # dct:title
+        sh:path dct:title ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-dct_title> ;
+        sh:message "El catálogo debe contener al menos un dct:title."@es ;
+        sh:message "The catalog must contain at least one dct:title."@en ;
+    ], 
+    [
+        sh:path dct:title ;
+        sh:node :LiteralMultilingualConvention ; 
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path dct:title ;
+        sh:node :NonEmptyLiteralConvention ; 
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path dct:title ;
+        sh:node :UniqueLangLiteralRestriction ;
+        sh:severity sh:Violation ;
+    ],
+
+    # dct:description
+    [
+        sh:path dct:description ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-dct_description> ;
+        sh:message "El catálogo debe contener al menos un dct:description."@es ;
+        sh:message "The catalog must contain at least one dct:description."@en ;
+    ], 
+    [
+        sh:path dct:description ;
+        sh:node :LiteralMultilingualConvention ; 
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path dct:description ;
+        sh:node :NonEmptyLiteralConvention ; 
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path dct:description ;
+        sh:node :UniqueLangLiteralRestriction ;
+        sh:severity sh:Violation ;
+    ],
+
+    # dct:publisher
+    [
+        sh:path dct:publisher ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-dct_publisher> ;
+        sh:message "El catálogo debe contener al menos un dct:publisher."@es ;
+        sh:message "The catalog must contain at least one dct:publisher."@en ;
+    ], 
+    [
+        sh:path dct:publisher ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-dct_publisher> ;
+        sh:message "La propiedad dct:publisher no puede tener más de un valor."@es ;
+        sh:message "The dct:publisher property cannot have more than one value."@en ;
+    ],
+    [
+        sh:path dct:publisher ;
+        sh:node :DIR3OrganismRestriction;
+        sh:or(
+            [
+                sh:nodeKind sh:IRI; 
+                sh:closed true ;
+            ]
+            [
+                sh:nodeKind sh:BlankNodeOrIRI;
+                sh:node :Agent_Shape;
+                sh:node :PublisherAgentRestriction;
+            ]
+        );
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-dct_publisher> ;
+        sh:message "El valor de dct:publisher debe ser un IRI o un nodo en blanco que cumpla con las restricciones de la forma de agente."@es ;
+        sh:message "The value of dct:publisher must be an IRI or a blank node that meets the agent shape restrictions."@en ;
+    ],
+    [
+        sh:path dct:publisher ;
+        sh:or(
+            [ 
+                sh:nodeKind sh:IRI;
+                sh:closed true
+            ]
+            [
+                sh:nodeKind sh:BlankNodeOrIRI;
+                sh:node :Agent_ShapeRecommended
+            ]
+        );
+        sh:severity sh:Warning;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-dct_publisher> ;
+        sh:message "El valor de dct:publisher debe ser un IRI o un nodo en blanco que cumpla con las restricciones de la forma de agente."@es ;
+        sh:message "The value of dct:publisher must be an IRI or a blank node that meets the agent shape restrictions."@en ;
+    ],
+
+    # foaf:homepage
+    [
+        sh:path foaf:homepage ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-foaf_homepage> ;
+        sh:message "La propiedad foaf:homepage no puede tener más de un valor."@es ;
+        sh:message "The foaf:homepage property cannot have more than one value."@en ;
+    ], 
+    [
+        sh:path foaf:homepage ;
+        sh:nodeKind sh:IRI; 
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-foaf_homepage> ;
+        sh:message "El valor de foaf:homepage debe ser un IRI válido."@es ;
+        sh:message "The value of foaf:homepage must be a valid IRI."@en ;
+    ], 
+    [
+        sh:path foaf:homepage ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-foaf_homepage> ;
+        sh:message "El catálogo debe contener al menos un foaf:homepage."@es ;
+        sh:message "The catalog must contain at least one foaf:homepage."@en ;
+    ], 
+
+    # dcat:themeTaxonomy
+    [
+        sh:path dcat:themeTaxonomy ;
+        sh:nodeKind sh:IRI; 
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-dcat_themetaxonomy> ;
+        sh:message "El valor de dcat:themeTaxonomy debe ser un IRI válido."@es ;
+        sh:message "The value of dcat:themeTaxonomy must be a valid IRI."@en ;
+    ], 
+    [
+        # Convencion 10
+        sh:path dcat:themeTaxonomy ;
+        sh:hasValue <http://datos.gob.es/kos/sector-publico/sector> ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-10> ;
+        sh:message "Se pueden utilizar varios temas, pero al menos <http://datos.gob.es/kos/sector-publico/sector> debe estar presente. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-10"@es ;
+        sh:message "Multiple themes can be used but at least <http://datos.gob.es/kos/sector-publico/sector> must be present. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-10"@en ;
+    ],    
+    [
+        # Convencion 11
+        sh:path dcat:themeTaxonomy ;
+        sh:in (
+            <http://datos.gob.es/kos/sector-publico/sector> 
+            <http://publications.europa.eu/resource/authority/data-theme>
+            <http://inspire.ec.europa.eu/theme>
+            );
+        sh:description "Only the themes <http://datos.gob.es/kos/sector-publico/sector>, <http://publications.europa.eu/resource/authority/data-theme> and <http://inspire.ec.europa.eu/theme> can be present"@en ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-11> ;
+        sh:message "Sólo pueden estar presentes las taxonomías <http://datos.gob.es/kos/sector-publico/sector>, <http://publications.europa.eu/resource/authority/data-theme> y <http://inspire.ec.europa.eu/theme>. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-11"@es ;
+        sh:message "Only the them taxonomies <http://datos.gob.es/kos/sector-publico/sector>, <http://publications.europa.eu/resource/authority/data-theme> and <http://inspire.ec.europa.eu/theme> can be present. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-11"@en ;
+    ],    
+    [
+        # Convencion 11
+        sh:path dcat:themeTaxonomy ;
+        sh:minCount 1 ;
+        sh:maxCount 3 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-11> ;
+        sh:message "El catálogo debe tener entre 1 y 3 valores para dcat:themeTaxonomy. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-11"@es ;
+        sh:message "The catalog must have between 1 and 3 values for dcat:themeTaxonomy. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-11"@en ;
+    ] ,
+
+    #dct:issued
+    [
+        sh:path dct:issued ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:node :DateOrDateTimeDataTypetConvention ;
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path dct:issued ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-dct_issued> ;
+        sh:message "El catálogo debe contener al menos un dct:issued."@es ;
+        sh:message "The catalog must contain at least one dct:issued."@en ;
+    ], 
+
+    #dct:modified
+    [
+        sh:path dct:modified ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:node :DateOrDateTimeDataTypetConvention ;
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path dct:modified ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-dct_modified> ;
+        sh:message "El catálogo debe contener al menos un dct:modified."@es ;
+        sh:message "The catalog must contain at least one dct:modified."@en ;
+    ], 
+
+    # dct:language
+    [
+        sh:path dct:language ;
+        sh:node :LanguageRestriction ;
+        sh:severity sh:Violation ;
+    ], 
+    [
+        sh:path dct:language ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-dct_language> ;
+        sh:message "El catálogo debe contener al menos un dct:language."@es ;
+        sh:message "The catalog must contain at least one dct:language."@en ;
+    ], 
+
+    # dct:license
+    [
+        sh:path dct:license ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-dct_license> ;
+        sh:message "La propiedad dct:license no puede tener más de un valor."@es ;
+        sh:message "The dct:license property cannot have more than one value."@en ;
+    ], 
+    [
+        sh:path dct:license ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-dct_license> ;
+        sh:message "El catálogo debe contener al menos un dct:license."@es ;
+        sh:message "The catalog must contain at least one dct:license."@en ;
+    ],  
+    [
+        sh:path dct:license ;
+        sh:or (
+            [ sh:node :LicenceDocumentRestriction ;]
+            [ sh:node :LicenceRestriction ;]
+            [ sh:nodeKind sh:IRI ;]
+        );
+        sh:severity sh:Violation ;
+    ], 
+
+    # dcat:dataset
+    [
+        sh:path dcat:dataset ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-dcat_dataset> ;
+        sh:message "El valor de dcat:dataset debe ser un IRI válido."@es ;
+        sh:message "The value of dcat:dataset must be a valid IRI."@en ;
+    ],
+
+    # dcat:service
+    [
+        sh:path dcat:service ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-dcat_service> ;
+        sh:message "El valor de dcat:service debe ser un IRI válido."@es ;
+        sh:message "The value of dcat:service must be a valid IRI."@en ;
+    ],
+
+    # dct:spatial
+    [
+        sh:path dct:spatial ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-dcat_spatial> ;
+        sh:message "El catálogo debe contener al menos un valor para dct:spatial."@es ;
+        sh:message "The catalog must contain at least one value for dct:spatial."@en ;
+    ],
+    [
+        sh:path dct:spatial ;
+        sh:or (
+            [ 
+                sh:class dct:Location ;
+                # WKT restriction
+                sh:node :SpatialGeometryConvention ; 
+            ]
+            [ 
+                sh:node :Spatial_Shape ;
+                sh:nodeKind sh:IRI ;
+                sh:severity sh:Violation;
+            ]
+        );
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-dcat_spatial> ;            
+        sh:message "El valor de dct:spatial debe ser un IRI de los vocabularios permitidos o un nodo de tipo Location."@es ;
+        sh:message "The value of dct:spatial must be an IRI from the allowed vocabularies or a Location node."@en ;
+    ],
+
+    # dcat:catalog
+    [
+        sh:path dcat:catalog ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-dcat_catalog> ;
+        sh:message "El valor de dcat:catalog debe ser un IRI válido."@es ;
+        sh:message "The value of dcat:catalog must be a valid IRI."@en ;
+    ],
+
+    # dcat:record    
+    [  
+        sh:path dcat:record ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-dcat_record> ;
+        sh:message "El valor de dcat:record debe ser un IRI válido."@es ;
+        sh:message "The value of dcat:record must be a valid IRI."@en ;
+    ],
+
+    #dct:creator  
+    [
+        sh:path dct:creator ;
+        sh:or(
+            [
+                sh:nodeKind sh:IRI; 
+                sh:closed true ;
+            ]
+            [
+                sh:nodeKind sh:BlankNodeOrIRI;
+                sh:node :Agent_Shape;
+                sh:node :CreatorAgentRestriction;
+            ]
+        );
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path dct:creator ;
+        sh:or(
+            [ 
+                sh:nodeKind sh:IRI;
+                sh:closed true
+            ]
+            [
+                sh:nodeKind sh:BlankNodeOrIRI;
+                sh:node :Agent_ShapeRecommended
+            ]
+        );
+        sh:severity sh:Warning ;
+    ],
+
+    #dct:hasPart
+    [
+        sh:path dct:hasPart ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-dct_haspart> ;
+        sh:message "El valor de dct:hasPart debe ser un IRI válido."@es ;
+        sh:message "The value of dct:hasPart must be a valid IRI."@en ;
+    ],
+
+    #dct:isPartOf 
+    [
+        sh:path dct:isPartOf ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-dct_ispart> ;
+        sh:message "La propiedad dct:isPartOf no puede tener más de un valor."@es ;
+        sh:message "The dct:isPartOf property cannot have more than one value."@en ;
+    ], 
+    [
+        sh:path dct:isPartOf ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-dct_ispart> ;
+        sh:message "El valor de dct:isPartOf debe ser un IRI válido."@es ;
+        sh:message "The value of dct:isPartOf must be a valid IRI."@en ;
+    ],
+
+    #dct:rights
+    [
+        sh:path dct:rights ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-dct_rights> ;
+        sh:message "La propiedad dct:rights no puede tener más de un valor."@es ;
+        sh:message "The dct:rights property cannot have more than one value."@en ;
+    ], 
+    [
+        sh:path dct:rights ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-dct_rights> ;
+        sh:message "El valor de dct:rights debe ser un IRI válido."@es ;
+        sh:message "The value of dct:rights must be a valid IRI."@en ;
+    ];  
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#dcat-catalog> ;
+    sh:targetClass dcat:Catalog .
+
+:CatalogDatasetOrServiceRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que un catálogo tenga al menos un conjunto de datos (dcat:dataset) o un servicio de datos (dcat:service)."@es ;
+    rdfs:comment "Restriction to validate that a catalog has at least one dataset (dcat:dataset) or one data service (dcat:service)."@en ;
+    rdfs:label "Restricción de catálogo: conjuntos de datos o servicios"@es ;
+    rdfs:label "Catalog restriction: datasets or services"@en ;
+    sh:name "Catalog Dataset or Service Restriction"@en ;
+    sh:or (
+        [
+            sh:path dcat:dataset ;
+            sh:minCount 1 ;
+            sh:severity sh:Violation ;
+            sh:message "El catálogo debe contener al menos un conjunto de datos (dcat:dataset)."@es ;
+            sh:message "The catalog must contain at least one dataset (dcat:dataset)."@en ;
+        ]
+        [
+            sh:path dcat:service ;
+            sh:minCount 1 ;
+            sh:severity sh:Violation ;
+            sh:message "El catálogo debe contener al menos un servicio de datos (dcat:service)."@es ;
+            sh:message "The catalog must contain at least one data service (dcat:service)."@en ;
+        ]
+    ) ;
+    sh:severity sh:Warning ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#dcat-catalog> ;
+    sh:targetClass dcat:Catalog .
+
+# Convencion 02
+:CatalogSPALanguageRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que un catálogo cumpla con las convenciones de idioma y contenido en español, incluyendo título, descripción y otros elementos clave."@es ;
+    rdfs:comment "Restriction to validate that a catalog complies with Spanish language and content conventions, including title, description, and other key elements."@en ;
+    rdfs:label "Restricción de catálogo: idioma y contenido en español"@es ;
+    rdfs:label "Catalog restriction: Spanish language and content"@en ;
+    sh:name "Catalog Spanish Language and Content Restriction"@en ;
+    sh:name "Restricción de catálogo para idioma y contenido en español"@en ;
+    sh:node :SpanishLanguageRestriction ;
+    sh:node :SpanishTitleRestriction ;
+    sh:node :SpanishDescriptionRestriction ;
+    sh:severity sh:Violation ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
+    sh:targetClass dcat:Catalog .

--- a/shacl/1.0.0/shacl_common_shapes.ttl
+++ b/shacl/1.0.0/shacl_common_shapes.ttl
@@ -1,0 +1,1051 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix : <http://datos.gob.es/dcat-ap-es#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix eli: <http://data.europa.eu/eli/ontology#> .
+@prefix schema: <http://schema.org/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcatapes: <https://datosgobes.github.io/DCAT-AP-ES/> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+
+<https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/shacl_common_shapes.ttl>
+    rdf:type owl:Ontology ;
+    rdfs:label "Restricciones comunes para DCAT-AP-ES"@es ;
+    rdfs:label "Common restrictions for DCAT-AP-ES"@en ;
+    dcat:downloadURL <https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/shacl_common_shapes.ttl> ;
+    dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE> ;
+    dct:conformsTo <https://www.w3.org/TR/shacl> ;
+    dct:description "Este archivo incluye restricciones SHACL comunes para propiedades y clases utilizadas en el perfil de aplicación DCAT-AP-ES."@es ;
+    dct:description "This file includes common SHACL restrictions for properties and classes used in the DCAT-AP-ES application profile."@en ;
+    owl:versionInfo "1.0.0" ;
+    dct:modified "2025-04-10"^^xsd:date ;
+    dct:publisher <http://datos.gob.es/recurso/sector-publico/org/Organismo/E0DAT0001> ;
+    cc:attributionURL <https://datos.gob.es/> ;
+    dcatap:availability <http://data.europa.eu/r5r/stable> ;
+    foaf:homepage <https://datosgobes.github.io/DCAT-AP-ES/> ;
+    rdfs:comment """
+        Este archivo incluye restricciones SHACL comunes que son necesarias para validar las propiedades y clases del perfil DCAT-AP-ES. 
+        Asegúrese de importar este archivo junto con otros archivos dependientes para una validación completa.
+    """@es ;
+    rdfs:comment """
+        This file includes common SHACL restrictions necessary to validate the properties and classes of the DCAT-AP-ES profile. 
+        Make sure to import this file along with other dependent files for full validation.
+    """@en .
+
+
+#--------------------------
+# Common restrictions
+#--------------------------
+:Agent_Shape
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que un agente tenga un nombre, un identificador y un tipo válidos, cumpliendo con las reglas de DCAT-AP-ES."@es ;
+    rdfs:comment "Restriction to validate that an agent has a valid name, identifier, and type, complying with DCAT-AP-ES rules."@en ;
+    rdfs:label "Restricción para agentes"@es ;
+    rdfs:label "Agent Restriction"@en ;
+    sh:property 
+    [
+    # foaf:name
+        sh:path foaf:name ;
+        sh:nodeKind sh:Literal ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-foaf_agent-foaf_name> ;
+        sh:message "El nombre del agente debe ser un literal válido."@es ;
+        sh:message "The agent's name must be a valid literal."@en ;
+    ],
+    [
+        sh:path foaf:name ;
+        sh:node :LiteralMultilingualConvention ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-foaf_agent-foaf_name> ;
+        sh:message "El nombre del agente debe ser multilingüe."@es ;
+        sh:message "The agent's name must be multilingual."@en ;
+    ],
+    [
+        sh:path foaf:name ;
+        sh:node :NonEmptyLiteralConvention ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-foaf_agent-foaf_name> ;
+        sh:message "El nombre del agente no puede estar vacío."@es ;
+        sh:message "The agent's name cannot be empty."@en ;
+    ],
+    [
+        sh:path foaf:name ;
+        sh:uniqueLang true ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-foaf_agent-foaf_name> ;
+        sh:message "Más de un valor comparten la misma etiqueta de idioma."@es ;
+        sh:message "More than one value shares the same language tag."@en ;
+    ],
+    [
+        sh:path foaf:name ;
+        sh:sparql [
+            sh:select """
+                PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+                SELECT $this
+                WHERE {
+                    FILTER EXISTS { $this foaf:name ?value }
+                    FILTER NOT EXISTS {
+                        $this foaf:name ?value .
+                        FILTER(isLiteral(?value) && LANG(?value) = "es")
+                    }
+                }
+            """ ;
+        ] ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-foaf_agent-foaf_name> ;
+        sh:message "El nombre del agente debe estar al menos en español."@es ;
+        sh:message "The agent's name value must be at least in Spanish."@en ;
+    ],
+    [
+        sh:path foaf:name ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-foaf_agent-foaf_name> ;
+        sh:message "Debe haber al menos un valor para el nombre del agente."@es ;
+        sh:message "There must be at least one value for the agent's name."@en ;
+    ],
+
+    # dct:identifier
+    [
+        sh:path dct:identifier ;
+        sh:nodeKind sh:Literal ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-foaf_agent-dct_identifier> ;
+        sh:message "El identificador del agente debe ser un literal válido."@es ;
+        sh:message "The agent's identifier must be a valid literal."@en ;
+    ],
+    [
+        sh:path dct:identifier ;
+        sh:node :NonEmptyLiteralConvention ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-foaf_agent-dct_identifier> ;
+        sh:message "El identificador del agente no puede estar vacío."@es ;
+        sh:message "The agent's identifier cannot be empty."@en ;
+    ],
+    [
+        sh:path dct:identifier ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-foaf_agent-dct_identifier> ;
+        sh:message "Solo puede haber un identificador para el agente."@es ;
+        sh:message "There can only be one identifier for the agent."@en ;
+    ],
+
+    # dct:type
+    [
+        sh:path dct:type ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-foaf_agent-dct_type> ;
+        sh:message "Solo puede haber un tipo para el agente."@es ;
+        sh:message "There can only be one type for the agent."@en ;
+    ],
+    [
+        sh:path dct:type ;
+        sh:nodeKind sh:IRI ;
+        sh:node :PublisherTypeRestriction ;
+        sh:description "Se utiliza un concepto no gestionado por la UE para indicar el tipo del agente. Si no se encuentra uno correspondiente, informe al mantenedor de la lista de códigos adms:publishertype."@es ;
+        sh:description "A non-EU managed concept is used to indicate the type of the agent. If no corresponding one can be found, inform the maintainer of the adms:publishertype codelist."@en ;
+        sh:severity sh:Violation ;
+    ] .
+
+:Agent_ShapeRecommended
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que un agente tenga al menos un identificador y un tipo, cumpliendo con las reglas de DCAT-AP-ES."@es ;
+    rdfs:comment "Restriction to validate that an agent has at least one identifier and one type, complying with DCAT-AP-ES rules."@en ;
+    rdfs:label "Restricción para agentes con identificador y tipo"@es ;
+    rdfs:label "Agent Restriction with Identifier and Type"@en ;
+    sh:name "Agent Shape recommended properties"@en ;
+    sh:property
+    # dct:identifier
+    [
+        sh:path dct:identifier ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-foaf_agent-dct_identifier> ;
+        sh:message "El agente debe tener al menos un identificador (dct:identifier)."@es ;
+        sh:message "The agent must have at least one identifier (dct:identifier)."@en ;
+    ],
+
+    # dct:type
+    [
+        sh:path dct:type ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-foaf_agent-dct_type> ;
+        sh:message "El agente debe tener al menos un tipo (dct:type)."@es ;
+        sh:message "The agent must have at least one type (dct:type)."@en ;
+    ] ;
+    sh:severity sh:Warning ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#foaf-agent> ;
+    sh:message "Se recomienda que el agente tenga al menos un identificador y un tipo."@es ;
+    sh:message "It is recommended that the agent has at least one identifier and one type."@en .
+
+:PublisherAgentRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que el tipo del nodo sea foaf:Agent o foaf:Organization."@es ;
+    rdfs:comment "Restriction to validate that the node type is foaf:Agent or foaf:Organization."@en ;
+    rdfs:label "Foma para agentes publicadores"@es ;
+    rdfs:label "Publisher Agent Shape"@en ;
+    sh:or ( 
+        [ sh:class foaf:Agent; ] 
+        [ sh:class foaf:Organization; ]
+    ) ;
+    sh:severity sh:Violation ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#foaf-agent> ;
+    sh:message "El tipo del nodo debe ser un foaf:Agent o foaf:Organization."@es ;
+    sh:message "The node type must be foaf:Agent or foaf:Organization."@en .
+
+:CreatorAgentRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que el creador de un recurso sea un agente válido, ya sea una persona, una organización o un agente genérico, cumpliendo con las reglas de DCAT-AP-ES."@es ;
+    rdfs:comment "Restriction to validate that the creator of a resource is a valid agent, either a person, an organization, or a generic agent, complying with DCAT-AP-ES rules."@en ;
+    rdfs:label "Restricción para agentes creadores"@es ;
+    rdfs:label "Creator Agent Restriction"@en ;
+    sh:name "Creator Agent Shape"@en ;
+    sh:or ( 
+        [ sh:class foaf:Agent; sh:nodeKind sh:IRI ] 
+        [ sh:class foaf:Organization; sh:nodeKind sh:IRI ]
+        [ sh:class foaf:Person; sh:nodeKind sh:IRI ]
+        [
+            sh:property [
+                sh:path rdf:type ;
+                sh:minCount 1 ; 
+                sh:in ( foaf:Agent foaf:Organization foaf:Person ) ;
+            ]
+        ]
+    ) ;
+    sh:severity sh:Violation ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#foaf-agent> ;
+    sh:message "El tipo del nodo debe ser foaf:Agent, foaf:Organization o foaf:Person."@es ;
+    sh:message "The node type must be foaf:Agent, foaf:Organization, or foaf:Person."@en .
+
+:SingleIRIRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción genérica para validar que una propiedad tenga un IRI válido."@es ;
+    rdfs:comment "Generic restriction to validate that a property has a valid IRI."@en ;
+    rdfs:label "Restricción de IRI válido"@es ;
+    rdfs:label "Valid IRI Restriction"@en ;
+    sh:nodeKind sh:IRI ;
+    sh:severity sh:Violation ;
+    sh:message "La propiedad debe ser un IRI válido."@es ;
+    sh:message "The property must be a valid IRI."@en .
+
+# Convencion 08
+:DateOrDateTimeDataTypetConvention
+    a sh:NodeShape ;
+    rdfs:comment "Convención para validar que un valor temporal sea de tipo xsd:dateTime, xsd:date, xsd:gYearMonth o xsd:gYear, siguiendo el formato ISO-8601."@es ;
+    rdfs:comment "Convention to validate that a temporal value is of type xsd:dateTime, xsd:date, xsd:gYearMonth, or xsd:gYear, following the ISO-8601 format."@en ;
+    rdfs:label "Convención de gestión de fechas de creación y modificación"@es ;
+    rdfs:label "Creation and modification date management convention"@en ;
+    sh:name "Convención de tipos de fecha o fecha y hora"@es ; 
+    sh:name "Date or DateTime Data Type Convention"@en ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-08> ;
+    sh:message "El valor debe ser de tipo xsd:date, xsd:dateTime, xsd:gYear o xsd:gYearMonth y seguir el formato ISO-8601."@es ;
+    sh:message "The value must be data typed as either xsd:date, xsd:dateTime, xsd:gYear, or xsd:gYearMonth and follow the ISO-8601 format."@en ;
+    sh:or (
+        [
+            sh:datatype xsd:dateTime ;
+            sh:pattern "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]{1,6})?(Z|[+-]((0[0-9]|1[0-3]):[0-5][0-9]|14:00))$" ;
+            sh:message "El valor debe ser de tipo xsd:dateTime y seguir el formato YYYY-MM-DDThh:mm:ssTZD."@es ;
+            sh:message "The value must be data typed xsd:dateTime and follow the format YYYY-MM-DDThh:mm:ssTZD."@en ;
+        ]
+        [
+            sh:datatype xsd:date ;
+            sh:pattern "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$" ;
+            sh:message "El valor debe ser de tipo xsd:date y seguir el formato YYYY-MM-DD."@es ;
+            sh:message "The value must be a valid data typed xsd:date and follow the format YYYY-MM-DD."@en ;
+        ]
+        [
+            sh:datatype xsd:gYearMonth ;
+            sh:pattern "^[1-9][0-9]{3}-(0[1-9]|1[0-2])$" ;
+            sh:message "El valor debe ser de tipo xsd:gYearMonth y seguir el formato YYYY-MM."@es ;
+            sh:message "The value must be a valid data typed xsd:gYearMonth and follow the format YYYY-MM."@en ;
+        ]
+        [
+            sh:datatype xsd:gYear ;
+            sh:pattern "^[1-9][0-9]{3}$" ;
+            sh:message "El valor debe ser de tipo xsd:gYear y seguir el formato YYYY."@es ;
+            sh:message "The value must be a valid data typed xsd:gYear and follow the format YYYY."@en ;
+        ]
+    ) ;
+    sh:severity sh:Violation .
+
+:DurationRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que un valor de duración siga el formato ISO 8601 para xsd:duration (por ejemplo, P3Y6M4DT12H30M5S)."@es ;
+    rdfs:comment "Restriction to validate that a duration value follows the ISO 8601 format for xsd:duration (e.g., P3Y6M4DT12H30M5S)."@en ;
+    rdfs:label "Restricción de duración"@es ;
+    rdfs:label "Duration Restriction"@en ;
+    sh:name "Restricción de duración"@es ;
+    sh:name "Duration Restrictione"@en ;
+    sh:nodeKind sh:Literal ;
+    sh:datatype xsd:duration ;
+    sh:pattern "^P(\\d+Y)?(\\d+M)?(\\d+D)?(T(\\d+H)?(\\d+M)?(\\d+(\\.\\d+)?S)?)?$" ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dcat_temporalresolution> ;
+    sh:message "El valor de duración debe seguir el formato ISO 8601 para xsd:duration (por ejemplo, P3Y6M4DT12H30M5S)."@es ;
+    sh:message "The duration value must follow the ISO 8601 format for xsd:duration (e.g., P3Y6M4DT12H30M5S)."@en ;
+    sh:severity sh:Violation .
+
+:EuropeanDataThemeRestriction
+    a sh:NodeShape ;
+    rdfs:comment "European Data Theme Restriction"@en ;
+    rdfs:label "European Data Theme Restriction"@en ;
+
+    # Pattern validation: it must be an IRI following the EU vocabulary format
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^http://publications\\.europa\\.eu/resource/authority/data-theme/.+$" ;
+    sh:message "The value must be an IRI from the European inspire vocabulary http://publications.europa.eu/resource/authority/data-theme."@en ;
+    sh:severity sh:Violation.
+
+:InspireDataThemeRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Inspire Data Theme Restriction"@en ;
+    rdfs:label "Inspire Data Theme Restriction"@en ;
+
+    # Pattern validation: it must be an IRI following the EU vocabulary format
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^http://inspire\\.ec\\.europa\\.eu/theme/.+$" ;
+    sh:message "The value must be an IRI from the European inspire vocabulary http://inspire.ec.europa.eu/theme."@en ;
+    sh:severity sh:Violation.
+
+# Convencion 19
+:VcardKindMinimalConvention
+    a sh:NodeShape ;
+    rdfs:comment "Convención para recomendar que un nodo conectado mediante dcat:contactPoint utilice vcard:fn, vcard:hasTelephone y vcard:hasUID, cumpliendo con las reglas de DCAT-AP-ES."@es ;
+    rdfs:comment "Convention to recommend that a node connected via dcat:contactPoint uses vcard:fn, vcard:hasTelephone, and vcard:hasUID, complying with DCAT-AP-ES rules."@en ;
+    rdfs:label "Restricción mínima para vcard:Kind"@es ;
+    rdfs:label "Minimal Restriction for vcard:Kind"@en ;
+    sh:name "Restricción mínima para vcard:Kind"@es ;
+    sh:name "vcard Kind Minimal Restriction"@en ;
+    sh:targetObjectsOf <http://www.w3.org/ns/dcat#contactPoint> ; # Aplica a nodos conectados con dcat:contactPoint
+    sh:property
+    [
+        sh:path vcard:fn ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message "Se recomienda incluir al menos un vcard:fn."@es ;
+        sh:message "It is recommended to include at least one vcard:fn."@en ;
+    ],
+    [
+        sh:path vcard:hasTelephone ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message "Se recomienda incluir al menos un vcard:hasTelephone."@es ;
+        sh:message "It is recommended to include at least one vcard:hasTelephone."@en ;
+    ],
+    [
+        sh:path vcard:hasUID ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message "Se recomienda incluir al menos un vcard:hasUID."@es ;
+        sh:message "It is recommended to include at least one vcard:hasUID."@en ;
+    ] ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-19> ;
+    sh:message "Se recomienda que el punto de contacto utilice vcard:fn, vcard:hasTelephone y vcard:hasUID. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-19"@es ;
+    sh:message "It is recommended that the contact point uses vcard:fn, vcard:hasTelephone, and vcard:hasUID. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-19"@en ;
+    sh:severity sh:Warning .
+
+:VcardKindRestriction
+    rdfs:comment "Restricción para validar que un nodo conectado mediante dcat:contactPoint sea de tipo vcard:Kind o una de sus subclases, cumpliendo con las reglas de DCAT-AP-ES."@es ;
+    rdfs:comment "Restriction to validate that a node connected via dcat:contactPoint is of type vcard:Kind or one of its subclasses, complying with DCAT-AP-ES rules."@en ;
+    rdfs:label "Restricción para vcard:Kind y subclases"@es ;
+    rdfs:label "Restriction for vcard:Kind and subclasses"@en ;
+    sh:name "vcard:Kind Restriction"@en ;
+    sh:targetObjectsOf <http://www.w3.org/ns/dcat#contactPoint> ; # Apply to connect nodes with dcat:contactPoint
+    # Class validation  (vcard:Kind o subclases)
+    sh:or ( 
+        [ sh:class vcard:Kind; sh:nodeKind sh:IRI ] 
+        [ sh:class vcard:Organization; sh:nodeKind sh:IRI ]
+        [ sh:class vcard:Group; sh:nodeKind sh:IRI ]
+        [ sh:class vcard:Individual; sh:nodeKind sh:IRI ]
+        [ sh:class vcard:Location; sh:nodeKind sh:IRI ]
+    ) ;
+    sh:property[
+    # vcard:organization-name
+        sh:path vcard:organization-name ;
+        sh:nodeKind sh:Literal;
+        sh:severity sh:Violation ;
+        sh:message "El nombre de la organización debe ser un literal válido."@es ;
+        sh:message "The organization's name must be a valid literal."@en ;
+    ],
+    [
+        sh:path vcard:organization-name ;
+        sh:node :NonEmptyLiteralConvention;
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path vcard:organization-name ;
+        sh:node :LiteralMultilingualConvention;
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path vcard:organization-name ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message "Debería contener al menos un vcard:organization-name."@es ;
+        sh:message "Should contain at least one vcard:organization-name."@en ;
+    ],
+    [
+        sh:path vcard:organization-name ;
+        sh:node :UniqueLangLiteralRestriction ;
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path vcard:organization-name ;        
+        sh:resultPath vcard:organization-name ; ;
+        sh:sparql [
+                sh:select """
+                PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
+                SELECT ?this
+                WHERE {
+                    ?this vcard:organization-name ?anyvalue .
+                    FILTER(isLiteral(?anyvalue)) 
+                    FILTER NOT EXISTS {
+                        ?this vcard:organization-name ?validValue .
+                        FILTER(isLiteral(?validValue) && LANG(?validValue) = "es")
+                    }
+                }
+                """;
+            ] ;
+        sh:severity sh:Violation ;
+        sh:message "El nombre de la organización debe estar al menos en español."@es ;
+        sh:message "The organization's name value must be at least in Spanish."@en ;
+    ],
+    # vcard:fn
+    [
+        sh:path vcard:fn ;
+        sh:nodeKind sh:Literal;
+        sh:severity sh:Violation ;
+        sh:message "El valor de vcard:fn debe ser un Literal."@es ;
+        sh:message "The value of vcard:fn must be a Literal."@en ;
+    ], 
+    [
+        sh:path vcard:fn ;
+        sh:node :LiteralMultilingualConvention ;
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path vcard:fn ;
+        sh:node :NonEmptyLiteralConvention ;
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path vcard:fn ;
+        sh:node :UniqueLangLiteralRestriction ;
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path vcard:fn ;
+        sh:resultPath vcard:fn ;
+        sh:sparql [
+                sh:select """
+                PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
+                SELECT ?this
+                WHERE {
+                    ?this vcard:fn ?anyvalue .
+                    FILTER(isLiteral(?anyvalue)) 
+                    FILTER NOT EXISTS {
+                        ?this vcard:fn ?validValue .
+                        FILTER(isLiteral(?validValue) && LANG(?validValue) = "es")
+                    }
+                }
+                """;
+            ] ;
+        sh:severity sh:Violation ;
+        sh:message "El valor de vcard:fn debe estar al menos en español."@es ;
+        sh:message "The value of vcard:fn must be at least in Spanish."@en ;
+    ],
+    [
+        sh:path vcard:fn ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message "vcard:fn Debería contener al menos un vcard:fn."@es ;
+        sh:message "vcard:fn should contain at least one vcard:fn."@en ;
+    ],
+    # vcard:hasUID
+    [
+        sh:path vcard:hasUID ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        sh:message "El valor de vcard:hasUID debe ser un IRI válido que apunte a un documento online."@es ;
+        sh:message "The value of vcard:hasUID must be a valid IRI pointing to an online document."@en ;
+    ],
+    [
+        sh:path vcard:hasUID ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message "Debería contener al menos un vcard:hasUID."@es ;
+        sh:message "Should contain at least one vcard:hasUID."@en ;
+    ],
+    [
+        sh:path vcard:hasUID ;
+        sh:maxCount 1;
+        sh:severity sh:Warning ;
+        sh:message "vcard:hasUID no debería contener más de un valor."@es ;
+        sh:message "vcard:hasUID should not contain more than one value.."@en ;
+    ],
+    # vcard:hasEmail (email)
+    [
+        sh:path vcard:hasEmail ;
+        sh:nodeKind sh:IRI;
+        sh:severity sh:Violation ;
+        sh:message "El valor de vcard:hasEmail debe ser un IRI válido que apunte directamente al email."@es ;
+        sh:message "The value of vcard:hasEmail must be a valid IRI that points directly to the email."@en ;
+    ], 
+    [
+        sh:path vcard:hasEmail ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message "Debería contener al menos un vcard:hasEmail."@es ;
+        sh:message "Should contain at least one vcard:hasEmail."@en ;
+    ],
+    [
+        sh:path vcard:hasEmail ;
+        sh:pattern "^mailto:.+" ;
+        sh:severity sh:Violation ;
+        sh:message "El valor vcard:hasEmail debe ser email válido, ej: <mailto:my.email@example.org>"@es ;
+        sh:message "The vcard:hasEmail value must be a valid email, e.g. <mailto:my.email@example.org>"@en ;
+    ],
+    # vcard:hasTelephone
+    [
+        sh:path vcard:hasTelephone ;
+        sh:nodeKind sh:IRI;
+        sh:severity sh:Violation ;
+        sh:message "El valor de vcard:hasTelephone debe ser un IRI válido que apunte directamente al email."@es ;
+        sh:message "The value of vcard:hasTelephone must be a valid IRI that points directly to the email."@en ;
+    ], 
+    [
+        sh:path vcard:hasTelephone ;
+        sh:minCount 1; 
+        sh:severity sh:Warning ;
+        sh:message "Debería contener al menos un vcard:hasTelephone."@es ;
+        sh:message "Should contain at least one vcard:hasTelephone."@en ;
+    ],
+    [
+        sh:path vcard:hasTelephone ;
+        sh:pattern "^tel:.+" ;
+        sh:severity sh:Violation ;
+        sh:message "El valor vcard:hasTelephone debe ser un teléfono válido, ej: <tel:+34900112233>"@es ;
+        sh:message "The vcard:hasTelephone value must be a valid phone number, e.g. <tel:+34900112233>."@en ;
+    ],
+    # vcard:hasURL (contact page)
+    [
+        sh:path vcard:hasURL ;
+        sh:nodeKind sh:IRI;
+        sh:severity sh:Violation ;
+        sh:message "El valor de vcard:hasURL debe ser un IRI válido."@es ;
+        sh:message "The value of vcard:hasURL must be a valid IRI."@en ;
+    ], 
+    [
+        sh:path vcard:hasURL ;
+        sh:minCount 1; 
+        sh:severity sh:Warning ;
+        sh:message "Debería contener al menos un vcard:hasURL."@es ;
+        sh:message "Should contain at least one vcard:hasURL."@en ;
+    ].
+    #sh:targetClass vcard:Kind .
+
+:VcardKindRestriction2
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que un nodo conectado mediante dcat:contactPoint sea de tipo vcard:Kind o una de sus subclases, y que contenga al menos un vcard:hasEmail o un vcard:hasURL, cumpliendo con las reglas de DCAT-AP-ES."@es ;
+    rdfs:comment "Restriction to validate that a node connected via dcat:contactPoint is of type vcard:Kind or one of its subclasses, and contains at least one vcard:hasEmail or vcard:hasURL, complying with DCAT-AP-ES rules."@en ;
+    rdfs:label "Restricción para vcard:Kind con email o URL"@es ;
+    rdfs:label "Restriction for vcard:Kind with email or URL"@en ;
+    sh:name "vcard Kind Restriction with Email or URL"@en ;
+    sh:targetObjectsOf <http://www.w3.org/ns/dcat#contactPoint> ; # Apply to connect nodes with dcat:contactPoint
+    sh:or ( 
+        [ sh:class vcard:Kind ] 
+        [ sh:class vcard:Organization ]
+        [ sh:class vcard:Group ]
+        [ sh:class vcard:Individual ]
+        [ sh:class vcard:Location ]
+    ) ;
+    sh:or (
+        [
+            sh:property [
+                sh:path vcard:hasEmail ;
+                sh:minCount 1 ;
+                sh:message "Debe contener al menos un vcard:hasEmail."@es ;
+                sh:message "Must contain at least one vcard:hasEmail."@en ;
+            ]
+        ]
+        [
+            sh:property [
+                sh:path vcard:hasURL ;
+                sh:minCount 1 ;
+                sh:message "Debe contener al menos un vcard:hasURL."@es ;
+                sh:message "Must contain at least one vcard:hasURL."@en ;
+            ]
+        ]
+    ) ;
+    sh:message "Debe proporcionarse al menos un vcard:hasEmail o vcard:hasURL."@es ;
+    sh:message "At least one of vcard:hasEmail or vcard:hasURL must be provided."@en ;
+    sh:severity sh:Violation .
+
+:LicenceDocumentRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que un documento de licencia tenga un tipo definido y que este sea un IRI válido del vocabulario de tipos de licencia."@es ;
+    rdfs:comment "Restriction to validate that a license document has a defined type and that it is a valid IRI from the license type vocabulary."@en ;
+    rdfs:label "Restricción de documento de licencia"@es ;
+    rdfs:label "License Document Restriction"@en ;
+    sh:name "Licence Document"@en ;
+    sh:property 
+    # dct:type
+    [
+        sh:path dct:type ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dct_license> ;
+        sh:message "El documento de licencia debe tener al menos un tipo definido."@es ;
+        sh:message "The license document must have at least one defined type."@en ;
+    ],
+    [
+        sh:path dct:type ;
+        sh:node :LicenceTypeRestriction ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dct_license> ;
+        sh:message "El tipo del documento de licencia debe ser un IRI válido del vocabulario de tipos de licencia."@es ;
+        sh:message "The type of the license document must be a valid IRI from the license type vocabulary."@en ;
+    ] ;
+    sh:targetClass dct:LicenseDocument .
+
+# Convencion 01:
+:LiteralMultilingualConvention
+    a sh:NodeShape;
+    rdfs:comment "Restricción para validar que un literal sea multilingüe, es decir, que tenga una etiqueta de idioma."@es ;
+    rdfs:comment "Restriction to validate that a literal is multilingual, meaning it must have a language tag."@en ;
+    rdfs:label "Restricción para literales multilingües"@es ;
+    rdfs:label "Multilingual Literal Restriction"@en ;
+    sh:nodeKind sh:Literal ;
+    sh:datatype rdf:langString ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-01> ;
+    sh:message "El literal debe ser multilingüe. Debe tener una etiqueta de idioma. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-01"@es ;
+    sh:message "The literal must be multilingual. It must have a language tag. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-01"@en ;
+    sh:severity sh:Violation .
+
+:Location_Shape
+    a sh:NodeShape ;
+    sh:name "Location"@en ;
+    # At least one or properties have to be
+    sh:or (
+        [ sh:property [
+            sh:path dcat:bbox ;
+            sh:minCount 1 ;
+            sh:severity sh:Violation ;  
+        ] ]
+        [ sh:property [
+            sh:path dcat:centroid ;
+            sh:minCount 1 ;
+            sh:severity sh:Violation ;  
+        ] ]
+        [ sh:property [
+            sh:path locn:geometry ;
+            sh:minCount 1 ;
+            sh:severity sh:Violation ;  
+        ] ]
+    ) ;
+    sh:message "At least one of dcat:bbox, dcat:centroid, or locn:geometry must be present. However, it is recommended to include dcat:bbox or dcat:centroid."@en ;
+    sh:property 
+    # dcat:bbox
+    [
+        sh:path dcat:bbox ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:severity sh:Violation
+    ], 
+    # dcat:centroid
+    [
+        sh:path dcat:centroid ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:severity sh:Violation
+    ], 
+    # locn:geometry
+    [
+        sh:path locn:geometry ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dct:Location .
+
+# Convencion 02
+:NonEmptyLiteralConvention
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que un literal no esté vacío ni contenga solo caracteres en blanco, tabulaciones o saltos de línea."@es ;
+    rdfs:comment "Restriction to validate that a literal is not empty or does not contain only whitespace characters, tabs, or line breaks."@en ;
+    rdfs:label "Restricción para literales no vacíos"@es ;
+    rdfs:label "Non-empty Literal Restriction"@en ;
+    sh:name "Not empty Literal"@en ;
+    sh:name "Literal no vacío"@es ;
+    sh:nodeKind sh:Literal ;
+    sh:minLength 1 ;
+    sh:pattern "^(?s)(?=.*\\S).*$" ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
+    sh:message "El literal no puede estar vacío ni contener solo caracteres en blanco, tabulaciones o saltos de línea. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@es ;
+    sh:message "The literal cannot be empty or contain only whitespace characters, tabs, or line breaks. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@en ;
+    sh:severity sh:Violation .
+
+# Convención 02
+:UniqueLangLiteralRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que los valores de un literal no compartan la misma etiqueta de idioma."@es ;
+    rdfs:comment "Restriction to validate that the values of a literal do not share the same language tag."@en ;
+    rdfs:label "Restricción para literales con etiquetas de idioma únicas"@es ;
+    rdfs:label "Unique Language Tag Literal Restriction"@en ;
+    sh:name "Unique Language Tag Literal"@en ;
+    sh:uniqueLang true ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
+    sh:message "Más de un valor comparten la misma etiqueta de idioma. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@es ;
+    sh:message "More than one value shares the same language tag. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@en ;
+    sh:severity sh:Violation .
+
+# Convención 02
+:NonLiteralMultilingualConvention
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que un literal no sea multilingüe, es decir, que no tenga una etiqueta de idioma."@es ;
+    rdfs:comment "Restriction to validate that a literal is not multilingual, meaning it must not have a language tag."@en ;
+    rdfs:label "Restricción para literales no multilingües"@es ;
+    rdfs:label "Non-multilingual Literal Restriction"@en ;
+    sh:name "Non-multilingual Literal"@en ;
+    sh:name "Literal sin etiqueta de idioma"@es ;
+    sh:nodeKind sh:Literal ;
+    sh:datatype xsd:string ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
+    sh:message "El literal no puede ser multilingüe. No debe tener una etiqueta de idioma. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-04"@es ;
+    sh:message "The literal cannot be multilingual. It must not have a language tag. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-04"@en ;
+    sh:severity sh:Violation .
+
+:NonNegativeIntegerRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que un valor sea un número entero no negativo, incluyendo cero."@es ;
+    rdfs:comment "Restriction to validate that a value is a non-negative integer, including zero."@en ;
+    rdfs:label "Restricción de entero no negativo"@es ;
+    rdfs:label "Non-negative Integer Restriction"@en ;
+    sh:name "Non-negative Integer"@en ;
+    sh:name "Número entero no negativo"@es ;
+    sh:nodeKind sh:Literal ;
+    sh:or ( 
+        [ 
+            sh:datatype xsd:integer ; 
+            sh:minInclusive 0 
+        ]
+        [ 
+            sh:datatype xsd:nonNegativeInteger 
+        ]
+    ) ;
+    sh:pattern "^[0-9]+$" ; # Número positivo, incluyendo 0
+    sh:message "El valor debe ser un número entero no negativo."@es ;
+    sh:message "The value must be a non-negative integer."@en ;
+    sh:severity sh:Violation .
+
+:PublicSectorRestriction
+    a sh:NodeShape ;
+    rdfs:comment "NTI-RISP sector vocabulary restriction."@en ;
+    rdfs:comment "Restricción del vocabulario de sectores de la NTI."@es ;
+    rdfs:label "NTI sector restriction"@en ;
+    rdfs:label "Restricción de vocabulario de sectores NTI"@es ;
+    sh:name "NTI sector restriction"@en ;
+    sh:name "Restricción de vocabulario de sectores NTI"@es ;
+    # Pattern validation: it must be an IRI of NTI-RISP sector vocabulary
+    #sh:nodeKind sh:IRI ;
+    sh:in (
+        <http://datos.gob.es/kos/sector-publico/sector/ciencia-tecnologia>
+        <http://datos.gob.es/kos/sector-publico/sector/comercio>
+        <http://datos.gob.es/kos/sector-publico/sector/cultura-ocio>
+        <http://datos.gob.es/kos/sector-publico/sector/demografia>
+        <http://datos.gob.es/kos/sector-publico/sector/deporte>
+        <http://datos.gob.es/kos/sector-publico/sector/economia>
+        <http://datos.gob.es/kos/sector-publico/sector/educacion>
+        <http://datos.gob.es/kos/sector-publico/sector/empleo>
+        <http://datos.gob.es/kos/sector-publico/sector/energia>
+        <http://datos.gob.es/kos/sector-publico/sector/hacienda>
+        <http://datos.gob.es/kos/sector-publico/sector/industria>
+        <http://datos.gob.es/kos/sector-publico/sector/legislacion-justicia>
+        <http://datos.gob.es/kos/sector-publico/sector/medio-ambiente>
+        <http://datos.gob.es/kos/sector-publico/sector/medio-rural-pesca>
+        <http://datos.gob.es/kos/sector-publico/sector/salud>
+        <http://datos.gob.es/kos/sector-publico/sector/sector-publico>
+        <http://datos.gob.es/kos/sector-publico/sector/seguridad>
+        <http://datos.gob.es/kos/sector-publico/sector/sociedad-bienestar>
+        <http://datos.gob.es/kos/sector-publico/sector/transporte>
+        <http://datos.gob.es/kos/sector-publico/sector/turismo>
+        <http://datos.gob.es/kos/sector-publico/sector/urbanismo-infraestructuras>
+        <http://datos.gob.es/kos/sector-publico/sector/vivienda>
+    );
+    sh:message "The value must be an IRI from the NTI-RISP sector vocabulary http://datos.gob.es/kos/sector-publico/sector."@en ;   
+    sh:severity sh:Violation .
+
+
+#Generic shape to validate that Spanish description is required
+:SpanishDescriptionRestriction
+    a sh:NodeShape ;
+    sh:name "SpanishDescriptionRestriction"@en ;
+    rdfs:comment "The description in spanish is required"@en ;
+    rdfs:label "Spanish Description Restriction"@en ;
+    sh:sparql [
+            sh:message "The description value must be at least in Spanish."@en ;
+            sh:select """
+                PREFIX dct: <http://purl.org/dc/terms/>
+                SELECT $this
+                WHERE {
+                FILTER EXISTS { $this dct:description ?value }
+                FILTER NOT EXISTS {
+                    $this dct:description ?value .
+                    FILTER(isLiteral(?value) && LANG(?value) = "es")
+                }
+            }
+            """ ;
+        ] ;
+    sh:severity sh:Violation .
+
+#Generic shape to validate that Spanish language is required
+:SpanishLanguageRestriction
+    a sh:NodeShape ;
+    sh:name "SpanishlanguageRestriction"@en ;
+    rdfs:comment "The Spanish language is required"@en ;
+    rdfs:label "Spanish language Restriction"@en ;
+    sh:sparql [
+        sh:message "The Spanish language, http://publications.europa.eu/resource/authority/language/SPA), is mandatory."@en ;
+        sh:select """
+            PREFIX dct: <http://purl.org/dc/terms/>
+            SELECT $this
+            WHERE {
+                FILTER EXISTS { $this dct:language ?value }
+                FILTER NOT EXISTS {
+                    $this dct:language <http://publications.europa.eu/resource/authority/language/SPA> .
+                }
+            }
+        """ ;
+        sh:severity sh:Violation ;
+    ] .
+
+#Generic shape to validate that Spanish title is required
+:SpanishTitleRestriction
+    a sh:NodeShape ;
+    sh:name "SpanishlanguageRestriction"@en ;
+    rdfs:comment "The title in spanish is required"@en ;
+    rdfs:label "Spanish title Restriction"@en ;
+    sh:sparql [
+            sh:message "The title value must be at least in Spanish."@en ;
+            sh:select """
+                PREFIX dct: <http://purl.org/dc/terms/>
+                SELECT $this
+                WHERE {
+                FILTER EXISTS { $this dct:title ?value }
+                FILTER NOT EXISTS {
+                    $this dct:title ?value .
+                    FILTER(isLiteral(?value) && LANG(?value) = "es")
+                }
+            }
+            """ ;
+        ] ;
+    sh:severity sh:Violation .
+
+:Spatial_Shape
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que un valor espacial sea un IRI válido de vocabularios permitidos, como territorios, países, lugares, continentes, unidades administrativas o GeoNames."@es ;
+    rdfs:comment "Restriction to validate that a spatial value is a valid IRI from allowed vocabularies, such as territories, countries, places, continents, administrative units, or GeoNames."@en ;
+    rdfs:label "Restricción para valores espaciales"@es ;
+    rdfs:label "Spatial Value Restriction"@en ;
+    sh:name "Spatial coverage value"@en ;
+    sh:name "Valor de cobertura geográfica"@es ;
+    sh:or (
+        :TerritoryRestriction
+        :CountryRestriction
+        :PlaceRestriction
+        :ContinentRestriction
+        :AtuRestriction
+        :GeoNamesRestriction
+    );
+    sh:severity sh:Violation ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#dcat-ap-es-vocabularies> ;
+    sh:message "El valor de dct:spatial debe ser un IRI de los vocabularios http://datos.gob.es/recurso/sector-publico/territorio, http://publications.europa.eu/resource/authority/country, http://publications.europa.eu/resource/authority/continent, http://publications.europa.eu/resource/authority/place o http://sws.geonames.org."@es ;
+    sh:message "The value of dct:spatial must be an IRI from the vocabularies http://datos.gob.es/recurso/sector-publico/territorio, http://publications.europa.eu/resource/authority/country, http://publications.europa.eu/resource/authority/continent, http://publications.europa.eu/resource/authority/place or http://sws.geonames.org."@en .
+
+:HVDCategoryRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que un valor sea un IRI perteneciente al vocabulario de categorías de distribución de la Unión Europea."@es ;
+    rdfs:comment "Restriction to validate that a value is an IRI from the European distribution status vocabulary."@en ;
+    rdfs:label "Restricción para categoría HVD"@es ;
+    rdfs:label "HVD Category Restriction"@en ;
+    sh:name "HVD Category"@en ;
+    sh:name "Categoría HVD"@es ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^http://data.europa.eu/bna/.+$" ;
+    sh:message "El valor debe ser un IRI del vocabulario de categorías de distribución de la Unión Europea (http://data.europa.eu/bna/asd487ae75)."@es ;
+    sh:message "The value must be an IRI from the European distribution status vocabulary (http://data.europa.eu/bna/asd487ae75)."@en ;
+    sh:severity sh:Violation .
+
+# Convención 07
+:ELIIdentifierRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que un valor sea un IRI que siga el patrón ELI o que sea de tipo eli:LegalResource."@es ;
+    rdfs:comment "Restriction to validate that a value is an IRI following the ELI pattern or is of type eli:LegalResource."@en ;
+    rdfs:label "Restricción para Identificadores ELI"@es ;
+    rdfs:label "ELI Identifier Restriction"@en ;
+    sh:name "ELI Identifier"@en ;
+    sh:name "Identificador ELI"@es ;
+    sh:or (
+        # Caso 1: Es un IRI que sigue el patrón ELI
+        [
+            sh:nodeKind sh:IRI ;
+            sh:pattern "^http://data\\.europa\\.eu/eli/.+$|^https://www\\.boe\\.es/eli/.+$" ;
+            sh:message "El valor debe ser un IRI que siga el patrón ELI para legislación europea o nacional (http://data.europa.eu/eli/... o https://www.boe.es/eli/...). Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-07"@es ;
+            sh:message "The value must be an IRI following the ELI pattern for European or national legislation (http://data.europa.eu/eli/... or https://www.boe.es/eli/...). See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-07"@en ;
+        ]
+        # Caso 2: Es de tipo eli:LegalResource
+        [
+            sh:class eli:LegalResource ;
+            sh:message "El valor debe ser de tipo eli:LegalResource. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-07"@es ;
+            sh:message "The value must be of type eli:LegalResource. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-07"@en ;
+        ]
+    ) ;
+    sh:severity sh:Violation ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-07> ;
+    sh:message "El valor debe ser un identificador ELI válido o de tipo eli:LegalResource. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-07"@es ;
+    sh:message "The value must be a valid ELI identifier or of type eli:LegalResource. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-07"@en .
+
+# Convencion 22
+:TemporalPeriodConvention
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que los períodos temporales sean descritos exclusivamente mediante las propiedades dcat:startDate y dcat:endDate dentro de dct:temporal, cumpliendo con la Convención 22 de DCAT-AP-ES."@es ;
+    rdfs:comment "Restriction to validate that temporal periods are described exclusively using dcat:startDate and dcat:endDate within dct:temporal, complying with DCAT-AP-ES Convention 22."@en ;
+    rdfs:label "Restricción para períodos temporales"@es ;
+    rdfs:label "Temporal Period Restriction"@en ;
+    sh:name "Temporal Period Restriction"@en ;
+    sh:name "Restricción para períodos temporales"@es ;
+    sh:targetClass dct:PeriodOfTime ;
+    sh:property [
+        sh:path dcat:startDate ;
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:dateTime ;
+        sh:message "El período temporal debe incluir al menos un dcat:startDate con un valor de tipo xsd:dateTime. Ver: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-22"@es ;
+        sh:message "The temporal period must include at least one dcat:startDate with a value of type xsd:dateTime. See: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-22"@en ;
+        sh:severity sh:Violation ;
+    ] ;
+    sh:property [
+        sh:path dcat:endDate ;
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:dateTime ;
+        sh:message "El período temporal debe incluir al menos un dcat:endDate con un valor de tipo xsd:dateTime. Ver: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-22"@es ;
+        sh:message "The temporal period must include at least one dcat:endDate with a value of type xsd:dateTime. See: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-22"@en ;
+        sh:severity sh:Violation ;
+    ] ;
+    sh:property [
+        sh:path schema:startDate ;
+        sh:severity sh:Warning ;
+        sh:message "Reemplace schema:startDate con dcat:startDate para cumplir con la Convención 22. Ver: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-22"@es ;
+        sh:message "Replace schema:startDate with dcat:startDate to comply with Convention 22. See: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-22"@en ;
+    ] ;
+    sh:property [
+        sh:path schema:endDate ;
+        sh:severity sh:Warning ;
+        sh:message "Reemplace schema:endDate con dcat:endDate para cumplir con la Convención 22. Ver: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-22"@es ;
+        sh:message "Replace schema:endDate with dcat:endDate to comply with Convention 22. See: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-22"@en ;
+    ] ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-22> ;
+    sh:message "El período temporal debe ser descrito exclusivamente mediante dcat:startDate y dcat:endDate dentro de dct:temporal. Ver: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-22"@es ;
+    sh:message "The temporal period must be described exclusively using dcat:startDate and dcat:endDate within dct:temporal. See: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-22"@en ;
+    sh:severity sh:Violation .
+
+:PeriodOfTimeRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que los nodos de tipo dct:PeriodOfTime tengan sus fechas de inicio y fin correctamente definidas."@es ;
+    rdfs:comment "Restriction to validate that nodes of type dct:PeriodOfTime have their start and end dates properly defined."@en ;
+    rdfs:label "Restricción para periodos de tiempo"@es ;
+    rdfs:label "Period of Time Restriction"@en ;
+    sh:name "Period of Time"@en ;
+    sh:name "Periodo de tiempo"@es ;
+    sh:property 
+    # dcat:startDate
+    [
+        sh:path dcat:startDate ;
+        sh:nodeKind sh:Literal ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        sh:node :DateOrDateTimeDataTypetConvention ;
+        sh:message "El valor de dcat:startDate debe ser un literal de tipo fecha o fecha-hora."@es ;
+        sh:message "The value of dcat:startDate must be a literal of type date or date-time."@en ;
+    ], 
+    [
+        sh:path dcat:startDate ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message "La propiedad dcat:startDate debería estar presente."@es ;
+        sh:message "The property dcat:startDate should be present."@en ;
+    ],
+    [
+        sh:path schema:startDate ;
+        sh:severity sh:Warning ;
+        sh:message "Reemplace la propiedad schema:startDate por dcat:startDate."@es ;
+        sh:message "Replace property schema:startDate with dcat:startDate."@en ;
+    ],
+    # dcat:endDate
+    [
+        sh:path dcat:endDate ;
+        sh:nodeKind sh:Literal ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        sh:node :DateOrDateTimeDataTypetConvention ;
+        sh:message "El valor de dcat:endDate debe ser un literal de tipo fecha o fecha-hora."@es ;
+        sh:message "The value of dcat:endDate must be a literal of type date or date-time."@en ;
+    ],
+    [
+        sh:path dcat:endDate ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message "La propiedad dcat:endDate debería estar presente."@es ;
+        sh:message "The property dcat:endDate should be present."@en ;
+    ], 
+    [
+        sh:path schema:endDate ;
+        sh:severity sh:Warning ;
+        sh:message "Reemplace la propiedad schema:endDate por dcat:endDate."@es ;
+        sh:message "Replace property schema:endDate with dcat:endDate."@en ;
+    ], 
+    # time:hasBeginning
+    [
+        sh:path time:hasBeginning ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message "La propiedad time:hasBeginning no puede tener más de un valor."@es ;
+        sh:message "The time:hasBeginning property cannot have more than one value."@en ;
+    ], 
+    [
+        sh:path time:hasBeginning ;
+        sh:class time:Instant ;
+        sh:severity sh:Violation ;
+        sh:message "El valor de time:hasBeginning debe ser un nodo de tipo time:Instant."@es ;
+        sh:message "The value of time:hasBeginning must be a node of type time:Instant."@en ;
+    ], 
+    # time:hasEnd
+    [
+        sh:path time:hasEnd ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message "La propiedad time:hasEnd no puede tener más de un valor."@es ;
+        sh:message "The time:hasEnd property cannot have more than one value."@en ;
+    ], 
+    [
+        sh:path time:hasEnd ;
+        sh:class time:Instant ;
+        sh:severity sh:Violation ;
+        sh:message "El valor de time:hasEnd debe ser un nodo de tipo time:Instant."@es ;
+        sh:message "The value of time:hasEnd must be a node of type time:Instant."@en ;
+    ] ;
+    sh:targetClass dct:PeriodOfTime .

--- a/shacl/1.0.0/shacl_dataservice_shape.ttl
+++ b/shacl/1.0.0/shacl_dataservice_shape.ttl
@@ -1,0 +1,405 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix : <http://datos.gob.es/dcat-ap-es#> .
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcatapes: <https://datosgobes.github.io/DCAT-AP-ES/> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+
+<https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/shacl_dataservice_shape.ttl>
+    rdf:type owl:Ontology ;
+    rdfs:label "Restricciones para los servicios de datos DCAT-AP-ES"@es ;
+    rdfs:label "Data service restrictions for DCAT-AP-ES"@en ;
+    dcat:downloadURL <https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/shacl_dataservice_shape.ttl> ;
+    dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE> ;
+    dct:conformsTo <https://www.w3.org/TR/shacl> ;
+    dct:description "Este archivo incluye las restricciones SHACL para las propiedades y clases relacionadas con servicios de datos en el perfil de aplicación DCAT-AP-ES."@es ;
+    dct:description "This file includes SHACL restrictions for properties and classes related to data services in the DCAT-AP-ES application profile."@en ;
+    owl:versionInfo "1.0.0" ;
+    dct:modified "2024-04-08"^^xsd:date ;
+    dct:publisher <http://datos.gob.es/recurso/sector-publico/org/Organismo/E0DAT0001> ;
+    cc:attributionURL <https://datos.gob.es/> ;
+    dcatap:availability <http://data.europa.eu/r5r/stable> ;
+    foaf:homepage <https://datosgobes.github.io/DCAT-AP-ES/> ;
+    rdfs:seeAlso <https://datosgobes.github.io/DCAT-AP-ES/#dcat-dataservice> ;
+    rdfs:comment """
+        Este archivo requiere importar las siguientes dependencias adicionales para funcionar correctamente:
+        - shacl_common_shapes.ttl
+        - shacl_mdr-vocabularies.shape.ttl
+        Asegúrese de que estén disponibles e importadas para una validación completa.
+    """@es ;
+    rdfs:comment """
+        This file requires importing the following additional dependencies to work properly:
+        - shacl_common_shapes.ttl
+        - shacl_mdr-vocabularies.shape.ttl
+        Make sure they are available and imported for full validation.
+    """@en .
+
+
+#--------------------------
+# dcat:DataService restrictions
+#--------------------------
+:DataService_Shape
+    a sh:NodeShape ;
+    sh:name "Servicio de Datos"@en ;
+    sh:name "Data Service"@en ;
+    rdfs:comment "Forma que define las restricciones para la clase dcat:DataService."@es ;
+    rdfs:comment "Shape defining restrictions for the dcat:DataService class."@en ;
+    rdfs:label "Restricciones de servicio de datos"@es ;
+    rdfs:label "Data service restrictions"@en ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#dcat-dataservice> ;
+    sh:property 
+    [
+    # dct:title
+        sh:path dct:title ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dct_title> ;
+        sh:message "El servicio de datos debe contener al menos un dct:title."@es ;
+        sh:message "The data service must contain at least one dct:title."@en ;
+    ], 
+    [
+        sh:path dct:title ;
+        sh:node :LiteralMultilingualConvention ; 
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path dct:title ;
+        sh:node :NonEmptyLiteralConvention ; 
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path dct:title ;
+        sh:node :UniqueLangLiteralRestriction ;
+        sh:severity sh:Violation ;
+    ],
+
+    # dcat:endpointURL
+    [
+        sh:path dcat:endpointURL ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcat_endpointurl> ;
+        sh:message "El valor de dcat:endpointURL debe ser un IRI válido."@es ;
+        sh:message "The value of dcat:endpointURL must be a valid IRI."@en ;
+    ],
+    [
+        sh:path dcat:endpointURL ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcat_endpointurl> ;
+        sh:message "El servicio de datos debe contener al menos un dcat:endpointURL."@es ;
+        sh:message "The data service must contain at least one dcat:endpointURL."@en ;
+    ], 
+
+    # dcatap:hvdCategory
+    [
+        sh:path dcatap:hvdCategory;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcatap_hvdcategory> ;
+        sh:message "El valor de dcatap:hvdCategory debe ser un IRI válido."@es ;
+        sh:message "The value of dcatap:hvdCategory must be a valid IRI."@en ;
+    ],
+    [
+        sh:path dcatap:hvdCategory;
+        sh:node :HVDCategoryRestriction ;
+        sh:severity sh:Violation ;
+    ],
+
+    # dcat:contactPoint
+    [
+        sh:path dcat:contactPoint ;
+        sh:not :DIR3OrganismRestriction ;
+        sh:severity sh:Violation
+    ],
+    [
+        sh:path dcat:contactPoint ;
+        sh:node :VcardKindMinimalConvention ;
+        sh:severity sh:Violation
+    ],
+    [
+        sh:path dcat:contactPoint ;
+        sh:node :VcardKindRestriction2 ;
+        sh:severity sh:Violation
+    ],
+    [
+        sh:path dcat:contactPoint ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcat_contactpoint> ;
+        sh:message "El servicio de datos debería contener al menos un dcat:contactPoint."@es ;
+        sh:message "The data service should contain at least one dcat:contactPoint."@en ;
+    ], 
+
+    # foaf:page
+    [
+        sh:path foaf:page ;
+        sh:nodeKind sh:IRI;
+        #sh:class foaf:Document ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-foaf_page> ;
+        sh:message "El valor de foaf:page debe ser un IRI válido."@es ;
+        sh:message "The value of foaf:page must be a valid IRI."@en ;
+    ], 
+    [
+        sh:path foaf:page ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-foaf_page> ;
+        sh:message "El servicio de datos debería contener al menos un foaf:page."@es ;
+        sh:message "The data service should contain at least one foaf:page."@en ;
+    ], 
+
+    # dcat:theme
+    [
+        sh:path dcat:theme ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcat_theme> ;
+        sh:message "El servicio de datos debe contener al menos un dcat:theme."@es ;
+        sh:message "The data service must contain at least one dcat:theme."@en ;
+    ], 
+    [
+		sh:path dcat:theme ;
+	    sh:qualifiedValueShape [
+			sh:node :PublicSectorRestriction ;
+		];	
+        sh:qualifiedMinCount 1;
+        sh:severity sh:Violation
+    ],
+    [
+        sh:path dcat:theme ;
+        sh:nodeKind sh:IRI ;
+        sh:or(
+            [   
+                sh:node :PublicSectorRestriction ;
+            ]
+            [   
+                sh:node :EuropeanDataThemeRestriction ;
+            ]
+            [
+                sh:node :InspireDataThemeRestriction ;
+            ]
+        );
+        sh:severity sh:Violation
+    ],
+
+    # dct:publisher
+    [
+        sh:path dct:publisher ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dct_publisher> ;
+        sh:message "El servicio de datos debe contener al menos un dct:publisher."@es ;
+        sh:message "The data service must contain at least one dct:publisher."@en ;
+    ], 
+    [
+        sh:path dct:publisher ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dct_publisher> ;
+        sh:message "La propiedad dct:publisher no puede tener más de un valor."@es ;
+        sh:message "The dct:publisher property cannot have more than one value."@en ;
+    ],
+    [
+        sh:path dct:publisher ;
+        sh:node :DIR3OrganismRestriction;
+        sh:or(
+            [
+                sh:nodeKind sh:IRI; 
+                sh:closed true ;
+            ]
+            [
+                sh:nodeKind sh:BlankNodeOrIRI;
+                sh:node :Agent_Shape;
+                sh:node :PublisherAgentRestriction;
+            ]
+        );
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dct_publisher> ;
+        sh:message "El valor de dct:publisher debe ser un IRI o un nodo en blanco que cumpla con las restricciones de la forma de agente."@es ;
+        sh:message "The value of dct:publisher must be an IRI or a blank node that meets the agent shape restrictions."@en ;
+    ],
+    [
+        sh:path dct:publisher ;
+        sh:or(
+            [ 
+                sh:nodeKind sh:IRI;
+                sh:closed true
+            ]
+            [
+                sh:nodeKind sh:BlankNodeOrIRI;
+                sh:node :Agent_ShapeRecommended
+            ]
+        );
+        sh:severity sh:Warning ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dct_publisher> ;
+        sh:message "El valor de dct:publisher debe ser un IRI o un nodo en blanco que cumpla con las restricciones de la forma de agente."@es ;
+        sh:message "The value of dct:publisher must be an IRI or a blank node that meets the agent shape restrictions."@en ;
+    ],
+
+    # dcat:endpointDescription
+    [
+        sh:path dcat:endpointDescription ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcat_endpointdescription> ;
+        sh:message "El valor de dcat:endpointDescription debe ser un IRI válido."@es ;
+        sh:message "The value of dcat:endpointDescription must be a valid IRI."@en ;
+    ],
+    [
+        sh:path dcat:endpointDescription ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcat_endpointdescription> ;
+        sh:message "El servicio de datos debería contener al menos un dcat:endpointDescription."@es ;
+        sh:message "The data service should contain at least one dcat:endpointDescription."@en ;
+    ], 
+
+    # dcat:servesDataset
+    [
+        sh:path dcat:servesDataset ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcat_servesdataset> ;
+        sh:message "El valor de dcat:servesDataset debe ser un IRI válido."@es ;
+        sh:message "The value of dcat:servesDataset must be a valid IRI."@en ;
+    ],
+    [
+        sh:path dcat:servesDataset ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcat_servesdataset> ;
+        sh:message "El servicio de datos debería contener al menos un dcat:servesDataset."@es ;
+        sh:message "The data service should contain at least one dcat:servesDataset."@en ;
+    ], 
+
+    # dcatap:applicableLegislation
+    [ 
+        sh:path dcatap:applicableLegislation ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcatap_applicablelegislation> ;
+        sh:message "El valor de dcatap:applicableLegislation debe ser un IRI válido."@es ;
+        sh:message "The value of dcatap:applicableLegislation must be a valid IRI."@en ;
+    ],
+    [
+        sh:path dcatap:applicableLegislation ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcatap_applicablelegislation> ;
+        sh:message "El servicio de datos debería contener al menos un dcatap:applicableLegislation."@es ;
+        sh:message "The data service should contain at least one dcatap:applicableLegislation."@en ;
+    ], 
+    [
+        sh:path dcatap:applicableLegislation ;
+        sh:node :ELIIdentifierRestriction ;
+        sh:severity sh:Violation ;
+    ],
+
+    # dct:description
+    [
+        sh:path dct:description ;
+        sh:nodeKind sh:Literal ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dct_description> ;
+        sh:message "El valor de dct:description debe ser un Literal."@es ;
+        sh:message "The value of dct:description must be a Literal."@en ;
+    ],
+    [
+        sh:path dct:description ;
+        sh:node :LiteralMultilingualConvention ; 
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path dct:description ;
+        sh:node :NonEmptyLiteralConvention ; 
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path dct:description ;
+        sh:node :UniqueLangLiteralRestriction ;
+        sh:severity sh:Violation ;
+    ],
+
+    # dct:accessRights
+    [
+        sh:path dct:accessRights ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dct_accessrights> ;
+        sh:message "La propiedad dct:publisher no puede tener más de un valor."@es ;
+        sh:message "The dct:publisher property cannot have more than one value."@en ;
+    ],
+    [
+        sh:path dct:accessRights ;
+		sh:node :AccessRightRestriction ;
+        sh:severity sh:Violation
+	],
+
+    # dct:license
+    [
+        sh:path dct:license ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dct_license> ;
+        sh:message "La propiedad dct:license no puede tener más de un valor."@es ;
+        sh:message "The dct:license property cannot have more than one value."@en ;
+    ],
+    [
+        sh:path dct:license ;
+        sh:or (
+            [ sh:node :LicenceDocumentRestriction ;]
+            [ sh:node :LicenceRestriction ;]
+            [ sh:nodeKind sh:IRI ;]
+        );
+        sh:severity sh:Violation ;
+    ],
+
+    # dcat:keyword
+    [
+        sh:path dcat:keyword ;
+        sh:nodeKind sh:Literal ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcat_keyword> ;
+        sh:message "El valor de dcat:keyword ser un Literal."@es ;
+        sh:message "The value of dcat:keyword must be a Literal."@en ;
+    ],
+    [
+        sh:path dcat:keyword ;
+        sh:node :LiteralMultilingualConvention ; 
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path dcat:keyword ;
+        sh:node :NonEmptyLiteralConvention ; 
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path dcat:keyword ;
+        sh:node :UniqueLangLiteralRestriction ;
+        sh:severity sh:Violation ;
+    ];
+    sh:targetClass dcat:DataService .
+
+# Convencion 02
+:DataServiceSPALanguageRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que un servicio de datos cumpla con las convenciones de idioma y contenido en español, incluyendo título, descripción y otros elementos clave."@es ;
+    rdfs:comment "Restriction to validate that a data service complies with Spanish language and content conventions, including title, description, and other key elements."@en ;
+    rdfs:label "Restricción de servicio de datos: idioma y contenido en español"@es ;
+    rdfs:label "Data service restriction: Spanish language and content"@en ;
+    sh:name "Data service Spanish Language and Content Restriction"@en ;
+    sh:name "Restricción de servicio de datos: idioma y contenido en español"@es ;
+    sh:node :SpanishLanguageRestriction ;
+    sh:node :SpanishTitleRestriction ;
+    sh:node :SpanishDescriptionRestriction ;
+    sh:severity sh:Violation ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
+    sh:targetClass dcat:DataService .

--- a/shacl/1.0.0/shacl_dataset_shape.ttl
+++ b/shacl/1.0.0/shacl_dataset_shape.ttl
@@ -1,0 +1,1120 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix : <http://datos.gob.es/dcat-ap-es#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcatapes: <https://datosgobes.github.io/DCAT-AP-ES/> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+
+<https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/shacl_dataset_shape.ttl>
+    rdf:type owl:Ontology ;
+    rdfs:label "Restricciones para los conjuntos de datos DCAT-AP-ES"@es ;
+    rdfs:label "Dataset restrictions for DCAT-AP-ES"@en ;
+    dcat:downloadURL <https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/shacl_dataset_shape.ttl> ;
+    dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE> ;
+    dct:conformsTo <https://www.w3.org/TR/shacl> ;
+    dct:description "Este archivo incluye las restricciones SHACL para las propiedades y clases relacionadas con conjuntos de datos en el perfil de aplicación DCAT-AP-ES."@es ;
+    dct:description "This file includes SHACL restrictions for properties and classes related to dataset in the DCAT-AP-ES application profile."@en ;
+    owl:versionInfo "1.0.0" ;
+    dct:modified "2024-04-08"^^xsd:date ;
+    dct:publisher <http://datos.gob.es/recurso/sector-publico/org/Organismo/E0DAT0001> ;
+    cc:attributionURL <https://datos.gob.es/> ;
+    dcatap:availability <http://data.europa.eu/r5r/stable> ;
+    foaf:homepage <https://datosgobes.github.io/DCAT-AP-ES/> ;
+    rdfs:seeAlso <https://datosgobes.github.io/DCAT-AP-ES/#dcat-dataset> ;
+    rdfs:comment """
+        Este archivo requiere importar las siguientes dependencias adicionales para funcionar correctamente:
+        - shacl_common_shapes.ttl
+        - shacl_mdr-vocabularies.shape.ttl
+        - shacl_distribution_shape.ttl
+        Asegúrese de que estén disponibles e importadas para una validación completa.
+    """@es ;
+    rdfs:comment """
+        This file requires importing the following additional dependencies to work properly:
+        - shacl_common_shapes.ttl
+        - shacl_mdr-vocabularies.shape.ttl
+        - shacl_distribution_shape.ttl
+        Make sure they are available and imported for full validation.
+    """@en .
+
+
+#--------------------------
+# dcat:Dataset restrictions
+#--------------------------
+:Dataset_Shape
+    a sh:NodeShape ;
+    sh:name "Conjunto de datos"@en ;
+    sh:name "Dataset"@en ;
+    rdfs:comment "Forma que define las restricciones para la clase dcat:Dataset."@es ;
+    rdfs:comment "Shape defining restrictions for the dcat:Dataset class."@en ;
+    rdfs:label "Restricciones de conjunto de datos"@es ;
+    rdfs:label "Dataset restrictions"@en ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#dcat-dataset> ;
+    sh:property 
+    [
+    # dct:title
+        sh:path dct:title ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_title> ;
+        sh:message "El conjunto de datos debe contener al menos un dct:title."@es ;
+        sh:message "The dataset must contain at least one dct:title."@en ;
+    ], 
+    [
+        sh:path dct:title ;
+        sh:node :LiteralMultilingualConvention ; 
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path dct:title ;
+        sh:node :NonEmptyLiteralConvention ; 
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path dct:title ;
+        sh:node :UniqueLangLiteralRestriction ;
+        sh:severity sh:Violation ;
+    ],
+
+    # dct:description
+    [
+        sh:path dct:description ;
+        sh:nodeKind sh:Literal ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_description> ;
+        sh:message "El valor de dct:description debe ser un Literal."@es ;
+        sh:message "The value of dct:description must be a Literal."@en ;
+    ], 
+    [
+        sh:path dct:description ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_description> ;
+        sh:message "El conjunto de datos debe contener al menos un dct:description."@es ;
+        sh:message "The dataset must contain at least one dct:description."@en ;
+    ], 
+    [
+        sh:path dct:description ;
+        sh:node :LiteralMultilingualConvention ;
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path dct:description ;
+        sh:node :NonEmptyLiteralConvention ;
+        sh:severity sh:Violation ; 
+    ],
+    [
+        sh:path dct:description ;
+        sh:node :UniqueLangLiteralRestriction ;
+        sh:severity sh:Violation ;
+    ],
+
+    # dct:publisher
+    [
+        sh:path dct:publisher ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_publisher> ;
+        sh:message "El conjunto de datos debe contener al menos un dct:publisher."@es ;
+        sh:message "The dataset must contain at least one dct:publisher."@en ;
+    ], 
+    [
+        sh:path dct:publisher ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_publisher> ;
+        sh:message "La propiedad dct:publisher no puede tener más de un valor."@es ;
+        sh:message "The dct:publisher property cannot have more than one value."@en ;
+    ],
+    [
+        sh:path dct:publisher ;
+        sh:node :DIR3OrganismRestriction;
+        sh:or(
+            [
+                sh:nodeKind sh:IRI; 
+                sh:closed true ;
+            ]
+            [
+                sh:nodeKind sh:BlankNodeOrIRI;
+                sh:node :Agent_Shape;
+                sh:node :PublisherAgentRestriction;
+            ]
+        );
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_publisher> ;
+        sh:message "El valor de dct:publisher debe ser un IRI o un nodo en blanco que cumpla con las restricciones de la forma de agente."@es ;
+        sh:message "The value of dct:publisher must be an IRI or a blank node that meets the agent shape restrictions."@en ;
+    ],
+    [
+        sh:path dct:publisher ;
+        sh:or(
+            [ 
+                sh:nodeKind sh:IRI;
+                sh:closed true
+            ]
+            [
+                sh:nodeKind sh:BlankNodeOrIRI;
+                sh:node :Agent_ShapeRecommended
+            ]
+        );
+        sh:severity sh:Warning ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_publisher> ;
+        sh:message "El valor de dct:publisher debe ser un IRI o un nodo en blanco que cumpla con las restricciones de la forma de agente."@es ;
+        sh:message "The value of dct:publisher must be an IRI or a blank node that meets the agent shape restrictions."@en ;
+    ],
+
+    # dcat:theme
+    [
+        sh:path dcat:theme ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dcat_theme> ;
+        sh:message "El conjunto de datos debe contener al menos un dcat:theme."@es ;
+        sh:message "The dataset must contain at least one dcat:theme."@en ;
+    ], 
+    [
+		sh:path dcat:theme ;
+	    sh:qualifiedValueShape [
+			sh:node :PublicSectorRestriction ;
+		];	
+        sh:qualifiedMinCount 1;
+        sh:severity sh:Violation
+    ],
+    [
+        sh:path dcat:theme ;
+        sh:nodeKind sh:IRI ;
+        sh:or(
+            [   
+                sh:node :PublicSectorRestriction ;
+            ]
+            [   
+                sh:node :EuropeanDataThemeRestriction ;
+            ]
+            [
+                sh:node :InspireDataThemeRestriction ;
+            ]
+        );
+        sh:severity sh:Violation
+    ],
+
+    # dcat:Distribution
+    [
+        sh:path dcat:distribution ;
+        sh:nodeKind sh:Literal ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dcat_distribution> ;
+        sh:message "El valor de dcat:distribution debe ser un Literal."@es ;
+        sh:message "The value of dcat:distribution must be a Literal."@en ;
+    ], 
+
+    # dcat:keyword
+    [
+        sh:path dcat:keyword ;
+        sh:nodeKind sh:Literal ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dcat_keyword> ;
+        sh:message "El valor de dcat:keyword ser un Literal."@es ;
+        sh:message "The value of dcat:keyword must be a Literal."@en ;
+    ],
+    [
+        sh:path dcat:keyword ;
+        sh:node :LiteralMultilingualConvention ; 
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path dcat:keyword ;
+        sh:node :NonEmptyLiteralConvention ; 
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path dcat:keyword ;
+        sh:node :UniqueLangLiteralRestriction ;
+        sh:severity sh:Violation ;
+    ],
+
+    # dcat:contactPoint
+    [
+        sh:path dcat:contactPoint ;
+        sh:not :DIR3OrganismRestriction ;
+        sh:severity sh:Violation
+    ],
+    [
+        sh:path dcat:contactPoint ;
+        sh:node :VcardKindMinimalConvention ;
+        sh:severity sh:Violation
+    ],
+    [
+        sh:path dcat:contactPoint ;
+        sh:node :VcardKindRestriction2 ;
+        sh:severity sh:Violation
+    ],
+    [
+        sh:path dcat:contactPoint ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dcat_contactpoint> ;
+        sh:message "El conjunto de datos debería contener al menos un dcat:contactPoint."@es ;
+        sh:message "The dataset should contain at least one dcat:contactPoint."@en ;
+    ], 
+
+    # dct:temporal
+    [
+        sh:path dct:temporal ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_temporal> ;
+        sh:message "El conjunto de datos debería contener al menos un dct:temporal."@es ;
+        sh:message "The dataset should contain at least one dct:temporal."@en ;
+    ], 
+    [
+        sh:path dcatap:applicableLegislation ;
+        sh:node :TemporalPeriodConvention ;
+        sh:severity sh:Violation ;
+    ],
+
+    # dct:spatial
+    [
+        sh:path dct:spatial ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dcat_spatial> ;
+        sh:message "El conjunto de datos debe contener al menos un valor para dct:spatial."@es ;
+        sh:message "The dataset must contain at least one value for dct:spatial."@en ;
+    ],
+
+    [
+        sh:path dct:spatial ;
+        sh:or (
+            [ 
+                sh:class dct:Location ;
+                # WKT restriction
+                sh:node :SpatialGeometryConvention ; 
+            ]
+            [ 
+                sh:node :Spatial_Shape ;
+                sh:nodeKind sh:IRI ;
+                sh:severity sh:Violation;
+            ]
+        );
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dcat_spatial> ;
+        sh:message "El valor de dct:spatial debe ser un IRI de los vocabularios permitidos o un nodo de tipo Location."@es ;
+        sh:message "The value of dct:spatial must be an IRI from the allowed vocabularies or a Location node."@en ;
+    ], 
+
+    # dct:identifier
+    [
+        sh:path dct:identifier ;
+        sh:nodeKind sh:Literal ;
+        sh:node :NonLiteralMultilingualConvention ;
+        sh:severity sh:Violation
+    ],
+    [
+        sh:path dct:identifier ;
+        sh:node :NonEmptyLiteralConvention;
+        sh:severity sh:Violation
+    ],
+
+    # adms:identifier
+    [
+        sh:path adms:identifier ;
+        sh:class adms:Identifier ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-adms_identifier> ;
+        sh:message "El valor de adms:identifier debe ser un adms:Identifier."@es ;
+        sh:message "The value of adms:identifier must be a adms:Identifier."@en ;
+    ], 
+
+    #dct:creator  
+    [
+        sh:path dct:creator ;
+        sh:or(
+            [
+                sh:nodeKind sh:IRI; 
+                sh:closed true ;
+            ]
+            [
+                sh:nodeKind sh:BlankNodeOrIRI;
+                sh:node :Agent_Shape;
+                sh:node :CreatorAgentRestriction;
+            ]
+        );
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path dct:creator ;
+        sh:or(
+            [ 
+                sh:nodeKind sh:IRI;
+                sh:closed true
+            ]
+            [
+                sh:nodeKind sh:BlankNodeOrIRI;
+                sh:node :Agent_ShapeRecommended
+            ]
+        );
+        sh:severity sh:Warning ;
+    ],
+
+    # foaf:page
+    [
+        sh:path foaf:page ;
+        sh:nodeKind sh:IRI;
+        #sh:class foaf:Document ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-foaf_page> ;
+        sh:message "El valor de foaf:page debe ser un IRI válido."@es ;
+        sh:message "The value of foaf:page must be a valid IRI."@en ;
+    ], 
+
+    # dcat:landingPage 
+    [
+        sh:path dcat:landingPage ;
+        sh:nodeKind sh:IRI;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dcat_landingpage> ;
+        sh:message "El valor de dcat:landingPage debe ser un IRI válido."@es ;
+        sh:message "The value of dcat:landingPage must be a valid IRI."@en ;
+    ], 
+
+    # adms:sample
+    [
+        sh:path adms:sample ;
+        sh:class dcat:Distribution ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-amds_sample> ;
+        sh:message "El valor de adms:sample debe ser un dcat:Distribution."@es ;
+        sh:message "The value of adms:sample must be a dcat:Distribution."@en ;
+    ], 
+
+    # dct:conformsTo 
+    [
+        sh:path dct:conformsTo ;
+        sh:nodeKind sh:IRI; 
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_conformsto> ;
+        sh:message "El valor de dct:conformsTo debe ser un IRI válido."@es ;
+        sh:message "The value of dct:conformsTo must be a valid IRI."@en ;
+    ], 
+
+    # dct:issued
+    [
+        sh:path dct:issued ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:node :DateOrDateTimeDataTypetConvention ;
+        sh:severity sh:Violation ;
+    ],
+
+    # dct:modified 
+    [
+        sh:path dct:modified ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:node :DateOrDateTimeDataTypetConvention ;
+        sh:severity sh:Violation ;
+    ], 
+
+    # dct:type
+    [
+        sh:path dct:type ;
+        #sh:class skos:Concept
+        sh:nodeKind sh:IRI ;
+        sh:or(
+            [
+                sh:node :DatasetTypeRestriction
+            ]
+            [
+                sh:node :INSPIREDatasetTypeRestriction
+            ]
+        );
+        sh:severity sh:Warning ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_type> ;
+        sh:message "El valor de dct:type debería ser un IRI de los vocabularios <http://publications.europa.eu/resource/authority/dataset-type> o <http://inspire.ec.europa.eu/metadata-codelist/ResourceType/dataset>"@es ;
+        sh:message "The value of dct:type should be an IRI from vocabularies <http://publications.europa.eu/resource/authority/dataset-type> or <http://inspire.ec.europa.eu/metadata-codelist/ResourceType/dataset>."@en ;
+    ], 
+
+    # dct:language
+    [
+        sh:path dct:language ;
+        sh:node :LanguageRestriction ;
+        sh:severity sh:Violation ;
+    ], 
+
+    # dct:accrualPeriodicity
+    [
+        sh:path dct:accrualPeriodicity ;
+        sh:or (
+            [ 
+                # IRI from european vocabulary
+                sh:nodeKind sh:IRI ;
+                sh:node :FrequencyRestriction ;
+            ]
+            [ 
+                # Frequency node
+                sh:class dct:Frequency ;
+            ]
+            [ 
+                # Literal of xsd:duration type (NTI legacy)
+                sh:nodeKind sh:Literal ;
+                sh:datatype xsd:duration ;
+                sh:node :DurationRestriction;
+            ]
+        );
+        sh:severity sh:Violation;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_accrualperiodicity> ;
+        sh:message "El valor de dct:accrualPeriodicity debe ser un IRI de los vocabularios permitidos o un Literal de tipo xsd:duration."@es ;
+        sh:message "The value of dct:accrualPeriodicity must be an IRI from the allowed vocabularies or a Literal of type xsd:duration."@en ;
+    ],
+
+    # dcat:version
+    [
+        sh:path dcat:version ;
+        sh:nodeKind sh:Literal ;
+        sh:node :NonLiteralMultilingualConvention ;
+        sh:severity sh:Violation
+    ],
+    [
+        sh:path dcat:version ;
+        sh:node :NonEmptyLiteralConvention ;
+        sh:severity sh:Violation
+    ],
+    [
+        sh:path dcat:version ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dcat_version> ;
+        sh:message "La propiedad dcat:version no puede tener más de un valor."@es ;
+        sh:message "The dcat:version property cannot have more than one value."@en ;
+    ],
+
+    # adms:versionNotes 
+    [
+        sh:path adms:versionNotes ;
+        sh:nodeKind sh:Literal ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-adms_versionnotes> ;
+        sh:message "El valor de adms:versionNotes debe ser un Literal."@es ;
+        sh:message "The value of adms:versionNotes must be a Literal."@en ;
+    ], 
+    [
+        sh:path adms:versionNotes ;
+        sh:node :LiteralMultilingualConvention ; 
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path adms:versionNotes ;
+        sh:node :NonEmptyLiteralConvention ; 
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path adms:versionNotes ;
+        sh:node :UniqueLangLiteralRestriction ;
+        sh:severity sh:Violation ;
+    ],
+
+    # dcat:hasVersion
+
+    [
+        sh:path dct:hasVersion ;
+        sh:nodeKind sh:IRI; 
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_hasversion> ;
+        sh:message "El valor de dct:hasVersion debe ser un IRI válido."@es ;
+        sh:message "The value of dct:hasVersion must be a valid IRI."@en ;
+    ], 
+
+    # dcat:isVersionOf
+    [
+        sh:path dct:isVersionOf ;
+        sh:nodeKind sh:IRI; 
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_isversionof> ;
+        sh:message "El valor de dct:isVersionOf debe ser un IRI válido."@es ;
+        sh:message "The value of dct:isVersionOf must be a valid IRI."@en ;
+    ], 
+
+    # dcat:qualifiedRelation
+    [
+        sh:path dcat:qualifiedRelation ;
+        sh:class dcat:Relationship ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dcat_qualifiedrelation> ;
+        sh:message "El valor de dcat:qualifiedRelation debe ser un dcat:Relationship."@es ;
+        sh:message "The value of dcat:isVersqualifiedRelationionOf must be a dcat:Relationship."@en ;
+    ], 
+
+    # dcat:spatialResolutionInMeters
+    [
+        sh:path dcat:spatialResolutionInMeters ;
+        sh:nodeKind sh:Literal ;
+        sh:or (
+            [ sh:datatype xsd:decimal ]
+            [ sh:datatype xsd:double ]
+        ) ;
+        sh:minInclusive 0;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dcat_spatialresolutioninmeters> ;
+        sh:message "El valor de dcat:spatialResolutionInMeters debe ser un Literal de tipo xsd:decimal o xsd:double."@es ;
+        sh:message "The value of dcat:spatialResolutionInMeters must be a Literal of type xsd:decimal or xsd:double."@en ;
+    ], 
+    [
+        sh:path dcat:spatialResolutionInMeters ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dcat_spatialresolutioninmeters> ;
+        sh:message "La propiedad dcat:spatialResolutionInMeters no puede tener más de un valor."@es ;
+        sh:message "The dcat:spatialResolutionInMeters property cannot have more than one value."@en ;
+    ],
+
+    # dcat:temporalResolution
+    [
+        sh:path dcat:temporalResolution ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dcat_temporalresolution> ;
+        sh:message "La propiedad dcat:temporalResolution no puede tener más de un valor."@es ;
+        sh:message "The dcat:temporalResolution property cannot have more than one value."@en ;
+    ],
+    [
+        sh:path dcat:temporalResolution ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:duration ;
+        sh:node :DurationRestriction;
+        sh:severity sh:Violation ;
+    ],
+
+    # dct:isReferencedBy
+    [
+        sh:path dct:isReferencedBy ;
+        sh:nodeKind sh:IRI; 
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_isreferencedby> ;
+        sh:message "El valor de dct:isReferencedBy debe ser un IRI válido."@es ;
+        sh:message "The value of dct:isReferencedBy must be a valid IRI."@en ;
+    ], 
+
+    # dct:provenance  
+    [
+        sh:path dct:provenance ;
+        sh:or(
+            [
+                sh:nodeKind sh:IRI ;
+                sh:closed true ;
+            ]
+            [
+        sh:property
+            [
+                sh:path rdf:type;
+                sh:hasValue dct:ProvenanceStatement ;
+                ]
+            ]
+        );
+        sh:message "The property dct:provenance must either be an IRI without an associated node, or an IRI describing a dct:ProvenanceStatement node.";
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_provenance> ;
+        sh:message "El valor de dct:provenance debe ser o bien un IRI sin nodo asociado, o bien un IRI que describa un nodo dct:ProvenanceStatement."@es ;
+        sh:message "The value of dct:provenance must either be an IRI without an associated node, or an IRI describing a dct:ProvenanceStatement node."@en ;
+    ],
+
+    # dct:relation
+    [
+        sh:path dct:relation ;
+        sh:nodeKind sh:IRI; 
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_relation> ;
+        sh:message "El valor de dct:relation debe ser un IRI válido."@es ;
+        sh:message "The value of dct:relation must be a valid IRI."@en ;
+    ], 
+
+    # prov:qualifiedAttribution   
+    [
+        sh:path prov:qualifiedAttribution ;
+        sh:class prov:Attribution ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-prov_qualifiedattribution> ;
+        sh:message "El valor de prov:qualifiedAttribution debe ser un nodo de tipo prov:Attribution."@es ;
+        sh:message "The value of prov:qualifiedAttribution must be a node of type prov:Attribution."@en ;
+    ], 
+
+    # prov:wasGeneratedBy
+    [
+        sh:path prov:wasGeneratedBy ;
+        sh:class prov:Activity ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-prov_wasgeneratedby> ;
+        sh:message "El valor de prov:wasGeneratedBy debe ser un nodo de tipo prov:Activity."@es ;
+        sh:message "The value of prov:wasGeneratedBy must be a node of type prov:Activity."@en ;
+    ], 
+
+    # dct:source
+    [
+        sh:path dct:source ;
+        sh:nodeKind sh:IRI; 
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_source> ;
+        sh:message "El valor de dct:source debe ser un IRI válido."@es ;
+        sh:message "The value of dct:source must be a valid IRI."@en ;
+    ], 
+
+    # dct:accessRights 
+    [
+        sh:path dct:accessRights ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_accessrights> ;
+        sh:message "La propiedad dct:accessRights no puede tener más de un valor."@es ;
+        sh:message "The dct:accessRights property cannot have more than one value."@en ;
+    ],
+    [
+        sh:path dct:accessRights ;
+        sh:nodeKind sh:IRI ;
+		sh:node :AccessRightRestriction ;
+        sh:severity sh:Violation ;
+	];
+    sh:targetClass dcat:Dataset .
+
+# Convencion 02
+:DatasetSPALanguageConvention
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que un conjunto de datos cumpla con las convenciones de idioma y contenido en español, incluyendo título, descripción y otros elementos clave."@es ;
+    rdfs:comment "Restriction to validate that a dataset complies with Spanish language and content conventions, including title, description, and other key elements."@en ;
+    rdfs:label "Restricción de conjunto de datos: idioma y contenido en español"@es ;
+    rdfs:label "Dataset restriction: Spanish language and content"@en ;
+    sh:name "Dataset Spanish Language and Content Restriction"@en ;
+    sh:name "Restricción de conjunto de datos: idioma y contenido en español"@es ;
+    sh:node :SpanishLanguageRestriction ;
+    sh:node :SpanishTitleRestriction ;
+    sh:node :SpanishDescriptionRestriction ;
+    sh:severity sh:Violation ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
+    sh:targetClass dcat:Dataset .
+
+# Convencion 23
+:DistributionMandatoryConvention
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que los conjuntos de datos contengan al menos una distribución (dcat:distribution), cumpliendo con la Convención 23 de DCAT-AP-ES."@es ;
+    rdfs:comment "Restriction to validate that datasets include at least one distribution (dcat:distribution), complying with DCAT-AP-ES Convention 23."@en ;
+    rdfs:label "Restricción para distribuciones obligatorias"@es ;
+    rdfs:label "Mandatory Distribution Restriction"@en ;
+    sh:targetClass dcat:Dataset ;
+    sh:property 
+    [
+        # dcat:distribution
+        sh:path dcat:distribution ;
+        sh:minCount 1 ;
+        sh:message "El conjunto de datos debe contener al menos una distribución (dcat:distribution). Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-23"@es ;
+        sh:message "The dataset must contain at least one distribution (dcat:distribution). See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-23"@en ;
+    ] ;
+    sh:severity sh:Violation ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-23> ;
+    sh:message "El conjunto de datos debe contener al menos una distribución (dcat:distribution). Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-23"@es ;
+    sh:message "The dataset must contain at least one distribution (dcat:distribution). See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-23"@en .
+
+#---------------------------
+# Other shapes restrictions
+#---------------------------
+
+:Activity_Shape
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que los nodos de tipo prov:Activity tengan propiedades temporales correctamente definidas."@es ;
+    rdfs:comment "Restriction to validate that nodes of type prov:Activity have properly defined temporal properties."@en ;
+    rdfs:label "Restricción para actividades"@es ;
+    rdfs:label "Activity Restriction"@en ;
+    sh:name "Restricción para actividades"@es ;
+    sh:name "Activity Restriction"@en ;
+    sh:property 
+    # prov:    sh:name "Activity Restriction"@en ;
+    [
+        sh:path prov:startedAtTime ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message "La propiedad prov:startedAtTime debería estar presente al menos una vez."@es ;
+        sh:message "The property prov:startedAtTime should be present at least once."@en ;
+    ], 
+    [
+        sh:path prov:startedAtTime ;
+        sh:nodeKind sh:Literal ;
+        sh:node :DateOrDateTimeDataTypetConvention ;
+        sh:severity sh:Violation ;
+        sh:message "El valor de prov:startedAtTime debe ser un literal de tipo fecha o fecha-hora."@es ;
+        sh:message "The value of prov:startedAtTime must be a literal of type date or date-time."@en ;
+    ],
+    # prov:endedAtTime
+    [
+        sh:path prov:endedAtTime ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message "La propiedad prov:endedAtTime debería estar presente al menos una vez."@es ;
+        sh:message "The property prov:endedAtTime should be present at least once."@en ;
+    ], 
+    [
+        sh:path prov:endedAtTime ;
+        sh:nodeKind sh:Literal ;
+        sh:node :DateOrDateTimeDataTypetConvention ;
+        sh:severity sh:Violation ;
+        sh:message "El valor de prov:endedAtTime debe ser un literal de tipo fecha o fecha-hora."@es ;
+        sh:message "The value of prov:endedAtTime must be a literal of type date or date-time."@en ;
+    ] ;
+    sh:targetClass prov:Activity .
+
+:Attribution_Shape
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que los nodos de tipo prov:Attribution tengan un agente y, opcionalmente, un rol definido."@es ;
+    rdfs:comment "Restriction to validate that nodes of type prov:Attribution have an agent and, optionally, a defined role."@en ;
+    rdfs:label "Restricción para atribuciones"@es ;
+    rdfs:label "Attribution Restriction"@en ;
+    sh:name "Restricción para atribuciones"@es ;
+    sh:name "Attribution Restriction"@en ;
+    sh:property 
+    # prov:agent
+    [
+        sh:path prov:agent ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation;
+        sh:message "La propiedad prov:agent debe estar presente al menos una vez."@es ;
+        sh:message "The property prov:agent must be present at least once."@en ;
+    ], 
+    [
+        sh:path prov:agent ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation;
+        sh:message "El valor de prov:agent debe ser un IRI."@es ;
+        sh:message "The value of prov:agent must be an IRI."@en ;
+    ], 
+    # dcat:hadRole
+    [
+        sh:path dcat:hadRole ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning;
+        sh:message "La propiedad dcat:hadRole debería estar presente al menos una vez."@es ;
+        sh:message "The property dcat:hadRole should be present at least once."@en ;
+    ], 
+    [
+        sh:path dcat:hadRole ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation;
+        sh:message "El valor de dcat:hadRole debe ser un IRI."@es ;
+        sh:message "The value of dcat:hadRole must be an IRI."@en ;
+    ];
+    sh:targetClass prov:Attribution .
+
+:DurationDescription_Shape
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que los nodos de tipo time:DurationDescription contengan exactamente una propiedad de medida temporal."@es ;
+    rdfs:comment "Restriction to validate that time:DurationDescription nodes contain exactly one temporal measurement property."@en ;
+    rdfs:label "Restricción para descripciones de duración"@es ;
+    rdfs:label "Duration Description Restriction"@en ;
+    sh:name "Descripción de duración temporal"@es ;
+    sh:name "Time Duration Description"@en ;
+    sh:targetClass time:DurationDescription ;
+    sh:xone (
+        :TimeYearsRestriction
+        :TimeMonthsRestriction
+        :TimeWeeksRestriction
+        :TimeDaysRestriction
+        :TimeHoursRestriction
+        :TimeMinutesRestriction
+        :TimeSecondsRestriction
+    );
+    sh:severity sh:Violation ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-time_durationdescription> ;
+    sh:message "Un time:DurationDescription debe tener exactamente una de las propiedades: time:years, time:months, time:weeks, time:days, time:hours, time:minutes, o time:seconds."@es ;
+    sh:message "A time:DurationDescription must have exactly one of the properties: time:years, time:months, time:weeks, time:days, time:hours, time:minutes, or time:seconds."@en .
+
+:Frequency_Shape
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que los nodos de tipo dct:Frequency contengan exactamente un valor de duración correctamente definido."@es ;
+    rdfs:comment "Restriction to validate that nodes of type dct:Frequency contain exactly one properly defined duration value."@en ;
+    rdfs:label "Restricción para frecuencias"@es ;
+    rdfs:label "Frequency Restriction"@en ;
+    sh:name "Frecuencia"@es ;
+    sh:name "Frequency"@en ;
+    sh:targetClass dct:Frequency ;
+    sh:property [
+        sh:path rdf:value ;
+        sh:or (
+            [ 
+                # Duration Description node
+                sh:class time:DurationDescription ;
+            ]
+            [ 
+                # Literal Duration
+                sh:nodeKind sh:Literal ;
+                sh:datatype xsd:duration ;
+                sh:node :DurationRestriction ;
+            ]
+        ) ;
+        sh:severity sh:Violation ;
+        sh:message "El valor de rdf:value debe ser un nodo de tipo time:DurationDescription o un literal de tipo xsd:duration."@es ;
+        sh:message "The value of rdf:value must be a node of type time:DurationDescription or a literal of type xsd:duration."@en ;
+    ],
+    [
+        sh:path rdf:value ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message "La propiedad rdf:value debe estar presente exactamente una vez."@es ;
+        sh:message "The rdf:value property must be present exactly once."@en ;
+    ],
+    [
+        sh:path rdf:value ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message "La propiedad rdf:value no puede tener más de un valor."@es ;
+        sh:message "The rdf:value property cannot have more than one value."@en ;
+    ] ;
+    sh:severity sh:Violation ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_frequency> ;
+    sh:message "El valor de dct:frequency debe ser un dct:Frequency."@es ;
+    sh:message "The value of dct:frequency must be a dct:Frequency."@en .
+
+:ADMSIdentifier_Shape
+    # https://www.w3.org/TR/vocab-adms/#identifier
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que los identificadores ADMS contengan exactamente un valor de notación no vacío."@es ;
+    rdfs:comment "Restriction to validate that ADMS identifiers contain exactly one non-empty notation value."@en ;
+    rdfs:label "Restricción para identificadores ADMS"@es ;
+    rdfs:label "ADMS Identifier Restriction"@en ;
+    sh:name "Identificador ADMS"@es ;
+    sh:name "Identifier"@en ;
+    sh:targetClass adms:Identifier ;
+    sh:property 
+    # skos:notation
+    [
+        sh:path skos:notation ;
+        sh:nodeKind sh:Literal ;
+        sh:node :NonLiteralMultilingualConvention ;
+        sh:severity sh:Violation ;
+        sh:message "El valor de skos:notation debe ser un literal sin etiqueta de idioma."@es ;
+        sh:message "The value of skos:notation must be a literal without a language tag."@en ;
+    ],
+    [
+        sh:path skos:notation ;
+        sh:node :NonEmptyLiteralConvention;
+        sh:severity sh:Violation ;
+        sh:message "El valor de skos:notation no puede estar vacío."@es ;
+        sh:message "The value of skos:notation cannot be empty."@en ;
+    ],
+    [
+        sh:path skos:notation ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message "La propiedad skos:notation debe estar presente al menos una vez."@es ;
+        sh:message "The skos:notation property must be present at least once."@en ;
+    ],
+    [
+        sh:path skos:notation ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message "La propiedad skos:notation no puede tener más de un valor."@es ;
+        sh:message "The skos:notation property cannot have more than one value."@en ;
+    ] ;
+    sh:severity sh:Violation ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-adms_identifier> ;
+    sh:message "El valor de adms:identifier debe ser un adms:Identifier."@es ;
+    sh:message "The value of adms:identifier must be a adms:Identifier."@en .
+    
+
+:Relationship_Shape
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que los nodos de tipo dcat:Relationship contengan las propiedades obligatorias correctamente definidas."@es ;
+    rdfs:comment "Restriction to validate that nodes of type dcat:Relationship contain properly defined mandatory properties."@en ;
+    rdfs:label "Restricción para relaciones"@es ;
+    rdfs:label "Relationship Restriction"@en ;
+    sh:name "Relación"@es ;
+    sh:name "Relationship"@en ;
+    sh:targetClass dcat:Relationship ;
+    sh:property 
+    # dct:relation 
+    [
+        sh:path dct:relation ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation;
+        sh:message "La propiedad dct:relation debe estar presente al menos una vez."@es ;
+        sh:message "The dct:relation property must be present at least once."@en ;
+    ], 
+    [
+        sh:path dct:relation ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation;
+        sh:message "El valor de dct:relation debe ser un IRI."@es ;
+        sh:message "The value of dct:relation must be an IRI."@en ;
+    ], 
+    # dcat:hadRole
+    [
+        sh:path dcat:hadRole ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation;
+        sh:message "La propiedad dcat:hadRole debe estar presente al menos una vez."@es ;
+        sh:message "The dcat:hadRole property must be present at least once."@en ;
+    ], 
+    [
+        sh:path dcat:hadRole ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation;
+        sh:message "El valor de dcat:hadRole debe ser un IRI."@es ;
+        sh:message "The value of dcat:hadRole must be an IRI."@en ;
+    ];
+    sh:severity sh:Violation ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dcat_qualifiedrelation> ;
+    sh:message "El valor de dcat:qualifiedRelation debe ser un dcat:Relationship."@es ;
+    sh:message "The value of dcat:qualifiedRelation must be a dcat:Relationship."@en .
+
+:TimeDaysRestriction
+    a sh:NodeShape ;
+    sh:property [
+        sh:path time:days ;
+        sh:node :NonNegativeIntegerRestriction ;
+        sh:maxCount 1 ;
+        sh:minCount 1;
+    ] .
+
+:TimeHoursRestriction
+    a sh:NodeShape ;
+    sh:property [
+        sh:path time:hours ;
+        sh:node :NonNegativeIntegerRestriction ;
+        sh:maxCount 1 ;
+        sh:minCount 1;
+    ] .
+
+:TimeMinutesRestriction
+    a sh:NodeShape ;
+    sh:property [
+        sh:path time:minutes ;
+        sh:node :NonNegativeIntegerRestriction ;
+        sh:maxCount 1 ;
+        sh:minCount 1;
+    ] .
+
+:TimeMonthsRestriction
+    a sh:NodeShape ;
+    sh:property [
+        sh:path time:months ;
+        sh:node :NonNegativeIntegerRestriction ;
+        sh:maxCount 1 ;
+        sh:minCount 1;
+    ] .
+
+:TimeSecondsRestriction
+    a sh:NodeShape ;
+    sh:property [
+        sh:path time:seconds ;
+        sh:node :NonNegativeIntegerRestriction ;
+        sh:maxCount 1 ;
+        sh:minCount 1;
+    ] .
+
+:TimeWeeksRestriction
+    a sh:NodeShape ;
+    sh:property [
+        sh:path time:weeks ;
+        sh:node :NonNegativeIntegerRestriction ;
+        sh:maxCount 1 ;
+        sh:minCount 1;
+    ] .
+
+:TimeYearsRestriction
+    a sh:NodeShape ;
+    sh:property [
+        sh:path time:years ;
+        #sh:node :NonNegativeIntegerRestriction ;
+        sh:maxCount 1 ;
+        sh:minCount 1;
+    ] .
+
+# Convencion 17
+:SpatialGeometryConvention
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que las referencias espaciales geométricas usen WKT (Well-Known Text) según GeoSPARQL, cumpliendo con la Convención 17 de DCAT-AP-ES."@es ;
+    rdfs:comment "Restriction to validate that spatial geometric references use WKT (Well-Known Text) according to GeoSPARQL, complying with DCAT-AP-ES Convention 17."@en ;
+    rdfs:label "Restricción para geometrías espaciales"@es ;
+    rdfs:label "Spatial Geometry Restriction"@en ;
+    sh:name "Spatial Geometry Restriction"@en ;
+    sh:name "Restricción para geometrías espaciales"@es ;
+    sh:targetClass dct:Location ;
+    sh:property
+    [
+        sh:path locn:geometry ;
+        sh:datatype geo:wktLiteral ;
+        sh:severity sh:Warning ;
+        sh:message "El valor de locn:geometry debería ser un literal en formato WKT (geo:wktLiteral). Ver: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-17"@es ;
+        sh:message "The value of locn:geometry should be a literal in WKT format (geo:wktLiteral). See: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-17"@en ;
+    ] ;
+    sh:property [
+        sh:path dcat:bbox ;
+        sh:datatype geo:wktLiteral ;
+        sh:severity sh:Warning ;
+        sh:message "El valor de dcat:bbox debería ser un literal en formato WKT (geo:wktLiteral). Ver: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-17"@es ;
+        sh:message "The value of dcat:bbox should be a literal in WKT format (geo:wktLiteral). See: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-17"@en ;
+    ] ;
+    sh:property [
+        sh:path dcat:centroid ;
+        sh:datatype geo:wktLiteral ;
+        sh:severity sh:Warning ;
+        sh:message "El valor de dcat:centroid debería ser un literal en formato WKT (geo:wktLiteral). Ver: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-17"@es ;
+        sh:message "The value of dcat:centroid should be a literal in WKT format (geo:wktLiteral). See: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-17"@en ;
+    ] ;
+    sh:severity sh:Warning ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-17> ;
+    sh:message "Las referencias espaciales geométricas deberían usar WKT (geo:wktLiteral) según GeoSPARQL. Ver: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-17"@es ;
+    sh:message "Spatial geometric references should use WKT (geo:wktLiteral) according to GeoSPARQL. See: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-17"@en .
+
+#--------------------------
+# Vocabulary restrictions
+#--------------------------
+:FrequencyRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que los valores de dct:accrualPeriodicity sean IRIs válidos del vocabulario europeo de frecuencias."@es ;
+    rdfs:comment "Restriction to validate that dct:accrualPeriodicity values are valid IRIs from the European frequency vocabulary."@en ;
+    rdfs:label "Restricción de frecuencia"@es ;
+    rdfs:label "Frequency Restriction"@en ;
+    sh:name "Frequency Restriction"@en ;
+    sh:name "Restricción de frecuencia"@es ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^http://publications\\.europa\\.eu/resource/authority/frequency/.+$" ;
+    sh:severity sh:Violation ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_accrualperiodicity> ;
+    sh:message "El valor debe ser un IRI del vocabulario europeo de frecuencias http://publications.europa.eu/resource/authority/frequency."@es ;
+    sh:message "The value must be an IRI from the European frequency vocabulary http://publications.europa.eu/resource/authority/frequency."@en .
+
+:DatasetTypeRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que los valores de dct:type sean IRIs válidos del vocabulario europeo de tipos de conjuntos de datos."@es ;
+    rdfs:comment "Restriction to validate that dct:type values are valid IRIs from the European dataset type vocabulary."@en ;
+    rdfs:label "Restricción de tipo de conjunto de datos"@es ;
+    rdfs:label "Dataset Type Restriction"@en ;
+    sh:name "Dataset Type Restriction"@en ;
+    sh:name "Restricción de tipo de conjunto de datos"@es ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^http://publications\\.europa\\.eu/resource/authority/dataset-type/.+$" ;
+    sh:severity sh:Violation ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_type> ;
+    sh:message "El valor debe ser un IRI del vocabulario europeo de tipos de conjunto de datos http://publications.europa.eu/resource/authority/dataset-type."@es ;
+    sh:message "The value must be an IRI from the European dataset type vocabulary http://publications.europa.eu/resource/authority/dataset-type."@en .
+
+:INSPIREDatasetTypeRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que los valores de dct:type para conjuntos de datos INSPIRE utilicen el IRI oficial especificado."@es ;
+    rdfs:comment "Restriction to validate that dct:type values for INSPIRE datasets use the official specified IRI."@en ;
+    rdfs:label "Restricción de tipo de conjunto de datos INSPIRE"@es ;
+    rdfs:label "INSPIRE Dataset Type Restriction"@en ;
+    sh:name "INSPIRE Dataset Type"@en ;
+    sh:name "Tipo de conjunto de datos INSPIRE"@es ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^http://inspire\\.ec\\.europa\\.eu/metadata-codelist/ResourceType/dataset$" ;
+    sh:severity sh:Violation ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_type> ;
+    sh:message "El valor debe ser exactamente el IRI http://inspire.ec.europa.eu/metadata-codelist/ResourceType/dataset."@es ;
+    sh:message "The value must be exactly the IRI http://inspire.ec.europa.eu/metadata-codelist/ResourceType/dataset."@en .
+

--- a/shacl/1.0.0/shacl_distribution_shape.ttl
+++ b/shacl/1.0.0/shacl_distribution_shape.ttl
@@ -1,0 +1,732 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix : <https://datosgobes.github.io/DCAT-AP-ES/> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix spdx: <http://spdx.org/rdf/terms#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcatapes: <https://datosgobes.github.io/DCAT-AP-ES/> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+
+<https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/shacl_distribution_shape.ttl>
+    rdf:type owl:Ontology ;
+    rdfs:label "Restricciones de distribución para DCAT-AP-ES"@es ;
+    rdfs:label "Distribution restrictions for DCAT-AP-ES"@en ;
+    dcat:downloadURL <https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/shacl_distribution_shape.ttl> ;
+    dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE> ;
+    dct:conformsTo <https://www.w3.org/TR/shacl> ;
+    dct:description "Este archivo incluye las restricciones SHACL para las propiedades y clases relacionadas con distribuciones en el perfil de aplicación DCAT-AP-ES."@es ;
+    dct:description "This file includes SHACL restrictions for properties and classes related to distributions in the DCAT-AP-ES application profile."@en ;
+    owl:versionInfo "1.0.0" ;
+    dct:modified "2024-04-08"^^xsd:date ;
+    dct:publisher <http://datos.gob.es/recurso/sector-publico/org/Organismo/E0DAT0001> ;
+    cc:attributionURL <https://datos.gob.es/> ;
+    dcatap:availability <http://data.europa.eu/r5r/stable> ;
+    foaf:homepage <https://datosgobes.github.io/DCAT-AP-ES/> ;
+    rdfs:seeAlso <https://datosgobes.github.io/DCAT-AP-ES/#dcat-distribution> ;
+    rdfs:comment """
+        Este archivo requiere importar las siguientes dependencias adicionales para funcionar correctamente:
+        - shacl_common_shapes.ttl
+        - shacl_mdr-vocabularies.shape.ttl
+        Asegúrese de que estén disponibles e importadas para una validación completa.
+    """@es ;
+    rdfs:comment """
+        This file requires importing the following additional dependencies to work properly:
+        - shacl_common_shapes.ttl
+        - shacl_mdr-vocabularies.shape.ttl
+        Make sure they are available and imported for full validation.
+    """@en .
+
+#--------------------------
+# dcat:Distribution restrictions
+#--------------------------
+:Distribution_Shape
+    a sh:NodeShape ;
+    sh:name "Distribución"@en ;
+    sh:name "Distribution"@en ;
+    rdfs:comment "Forma que define las restricciones para la clase dcat:Distribution."@es ;
+    rdfs:comment "Shape defining restrictions for the dcat:Distribution class."@en ;
+    rdfs:label "Restricciones de distribución"@es ;
+    rdfs:label "Distribution restrictions"@en ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#dcat-distribution> ;
+    sh:property 
+    [
+    # dcat:accessURL
+        sh:path dcat:accessURL ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dcat_accessurl> ;
+        sh:message "El valor de dcat:accessURL debe ser un IRI válido para dcat:accessURL."@es ;
+        sh:message "The value of dcat:accessURL must be a valid IRI for dcat:accessURL."@en ;
+    ],
+    [
+        sh:path dcat:accessURL ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dcat_accessurl> ;
+        sh:message "La distribución debe contener al menos un dcat:accessURL."@es ;
+        sh:message "The distribution must contain at least one dcat:accessURL."@en ;
+    ],
+
+    [
+    # dcatap:applicableLegislation
+        sh:path dcatap:applicableLegislation ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dcatap_applicablelegislation> ;
+        sh:message "El valor de dcatap:applicableLegislation debe ser un IRI válido."@es ;
+        sh:message "The value of dcatap:applicableLegislation must be a valid IRI."@en ;
+    ],
+    [
+        sh:path dcatap:applicableLegislation ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dcatap_applicablelegislation> ;
+        sh:message "La distribución debería contener al menos un dcatap:applicableLegislation."@es ;
+        sh:message "The distribution should contain at least one dcatap:applicableLegislation."@en ;
+    ], 
+    [
+        sh:path dcatap:applicableLegislation ;
+        sh:node :ELIIdentifierRestriction ;
+        sh:severity sh:Violation ;
+    ],
+
+    # dct:description
+    [
+        sh:path dct:description ;
+        sh:nodeKind sh:Literal ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dct_description> ;
+        sh:message "El valor de dct:description debe ser un Literal."@es ;
+        sh:message "The value of dct:description must be a Literal."@en ;
+    ], 
+    [
+        sh:path dct:description ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dct_description> ;
+        sh:message "La distribución debería contener al menos un dct:description."@es ;
+        sh:message "The distribution should contain at least one dct:description."@en ;
+    ], 
+    [
+        sh:path dct:description ;
+        sh:node :LiteralMultilingualConvention ;
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path dct:description ;
+        sh:node :NonEmptyLiteralConvention ;
+        sh:severity sh:Violation ; 
+    ],
+    [
+        sh:path dct:description ;
+        sh:node :UniqueLangLiteralRestriction ;
+        sh:severity sh:Violation ;
+    ],
+
+    # dcatap:availability
+    [
+        sh:path dcatap:availability ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dcatap_availability> ;
+        sh:message "El valor de dcatap:availability debe ser un IRI válido."@es ;
+        sh:message "The value of dcatap:availability must be a valid IRI."@en ;
+    ],
+    [
+        sh:path dcatap:availability ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dcatap_availability> ;
+        sh:message "La propiedad dcatap:availability no puede tener más de un valor."@es ;
+        sh:message "The dcatap:availability property cannot have more than one value."@en ;
+    ],
+    [
+        sh:path dcatap:availability ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dcatap_availability> ;
+        sh:message "La distribución debería contener al menos un dcatap:availability."@es ;
+        sh:message "The distribution should contain at least one dcatap:availability."@en ;
+    ],  
+    [
+        sh:path dcatap:availability ;
+        sh:node :AvailabilityRestriction ;
+        sh:severity sh:Violation ;
+    ],
+
+    # dct:format
+    [
+        sh:path dct:format ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dct_format> ;
+        sh:message "La propiedad dct:format no puede tener más de un valor."@es ;
+        sh:message "The dct:format property cannot have more than one value."@en ;
+    ], 
+    [
+        sh:path dct:format ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dct_format> ;
+        sh:message "La distribución debería contener al menos un dct:format."@es ;
+        sh:message "The distribution should contain at least one dct:format."@en ;
+    ],  
+    [
+        sh:path dct:format ;
+        sh:or (
+            [ 
+                sh:node :FileTypeRestriction ;
+                sh:nodeKind sh:IRI ;
+            ]
+            #TODO: Review DCAT-AP-ES model
+            #[ sh:class dct:MediaTypeOrExtent ;]
+            [
+                # Legacy NTI-RISP: https://datosgobes.github.io/NTI-RISP/#distribucion_-_clase_dcatdistribution_-_obligatorio
+                sh:class dct:IMT ;
+                
+            ]
+        );
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dct_format> ;
+        sh:message "El valor de dct:format debe ser un IRI válido del vocabulario europeo de tipos de archivo o un literal de tipo dct:IMT."@es ;
+        sh:message "The value of dct:format must be a valid IRI from the European file type vocabulary or a literal of type dct:IMT."@en ;
+    ],
+
+    # dct:license
+    [
+        sh:path dct:license ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dct_license> ;
+        sh:message "La propiedad dct:license no puede tener más de un valor."@es ;
+        sh:message "The dct:license property cannot have more than one value."@en ;
+    ], 
+    [
+        sh:path dct:license ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dct_license> ;
+        sh:message "La distribución debería contener al menos un dct:license."@es ;
+        sh:message "The distribution should contain at least one dct:license."@en ;
+    ],  
+    [
+        sh:path dct:license ;
+        sh:or (
+            [ sh:node :LicenceDocumentRestriction ;]
+            [ sh:node :LicenceRestriction ;]
+            [ sh:nodeKind sh:IRI ;]
+        );
+        sh:severity sh:Violation ;
+    ], 
+
+    # dcat:accessService
+    [
+        sh:path dcat:accessService ;     
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dcat_accessservice> ;
+        sh:message "El valor de dcat:accessService debe ser un IRI válido que apunte a un servicio de acceso."@es ;
+        sh:message "The value of dcat:accessService must be a valid IRI pointing to an access service."@en ;
+    ],
+
+    # dct:title
+    [
+        sh:path dct:title ;
+        sh:nodeKind sh:Literal ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dct_title> ;
+        sh:message "El valor de dct:title debe ser un Literal."@es ;
+        sh:message "The value of dct:title must be a Literal."@en ;
+    ], 
+    [
+        sh:path dct:title ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dct_title> ;
+        sh:message "La distribución debería contener al menos un dct:title."@es ;
+        sh:message "The distribution should contain at least one dct:title."@en ;
+    ], 
+    [
+        sh:path dct:title ;
+        sh:node :LiteralMultilingualConvention ;
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path dct:title ;
+        sh:node :NonEmptyLiteralConvention ;
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path dct:title ;
+        sh:node :UniqueLangLiteralRestriction ;
+        sh:severity sh:Violation ;
+    ],
+
+    # foaf:page
+    [
+        sh:path foaf:page ;     
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-foaf_page> ;
+        sh:message "El valor de foaf:page debe ser un IRI válido que apunte a un documento online."@es ;
+        sh:message "The value of foaf:page must be a valid IRI pointing to an online document."@en ;
+    ],
+
+    # dcat:mediaType
+    [
+        sh:path dcat:mediaType ;
+        sh:nodeKind sh:IRI ;
+        sh:node :IanaFormatRestriction;
+        sh:severity sh:Violation ;
+    ], 
+    [
+        sh:path dcat:mediaType ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dcat_mediatype> ;
+        sh:message "La propiedad dcat:mediaType no puede tener más de un valor."@es ;
+        sh:message "The dcat:mediaType property cannot have more than one value."@en ;
+    ], 
+
+    # dcat:downloadURL
+    [
+        sh:path dcat:downloadURL ;
+        sh:nodeKind sh:IRI;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dcat_downloadurl> ;
+        sh:message "El valor de dcat:downloadURL debe ser un IRI válido que apunte directamente al archivo de datos."@es ;
+        sh:message "The value of dcat:downloadURL must be a valid IRI that points directly to the data file."@en ;
+    ], 
+
+    # dct:conformsTo 
+    [
+        sh:path dct:conformsTo ;
+        sh:nodeKind sh:IRI; 
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dct_conformsto> ;
+        sh:message "El valor de dct:conformsTo debe ser un IRI válido."@es ;
+        sh:message "The value of dct:conformsTo must be a valid IRI."@en ;
+    ], 
+
+    # dct:issued
+    [
+        sh:path dct:issued ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:node :DateOrDateTimeDataTypetConvention ;
+        sh:severity sh:Violation ;
+    ],
+
+    # dct:modified 
+    [
+        sh:path dct:modified ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:node :DateOrDateTimeDataTypetConvention ;
+        sh:severity sh:Violation ;
+    ], 
+
+    # adms:status
+    [
+        sh:path adms:status ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-adms_status> ;
+        sh:message "La propiedad adms:status no puede tener más de un valor."@es ;
+        sh:message "The adms:status property cannot have more than one value."@en ;
+    ], 
+    [
+        sh:path adms:status ;
+        sh:node :StatusRestriction ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+    ], 
+
+    # dct:language
+    [
+        sh:path dct:language ;
+        sh:node :LanguageRestriction ;
+        sh:severity sh:Violation ;
+    ], 
+
+    # dcat:compressFormat
+    [
+        sh:path dcat:compressFormat ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dcat_compressformat> ;
+        sh:message "La propiedad dcat:compressFormat no puede tener más de un valor."@es ;
+        sh:message "The dcat:compressFormat property cannot have more than one value."@en ;
+    ], 
+    [
+        sh:path dcat:compressFormat ;
+        sh:nodeKind sh:IRI ;
+        sh:node :IanaFormatRestriction;
+    ], 
+    
+    # dcat:packageFormat 
+    [
+        sh:path dcat:packageFormat ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dcat_packageformat> ;
+        sh:message "La propiedad dcat:packageFormat no puede tener más de un valor."@es ;
+        sh:message "The dcat:packageFormat property cannot have more than one value."@en ;
+    ], 
+    [
+        sh:path dcat:packageFormat ;
+        sh:nodeKind sh:IRI ;
+        sh:node :IanaFormatRestriction;
+        sh:severity sh:Violation ;
+    ], 
+
+    # dcat:byteSize
+    [
+        sh:path dcat:byteSize ;
+        sh:nodeKind sh:Literal;
+        sh:or(
+            [
+                sh:none :NonNegativeIntegerRestriction ;
+            ]
+            [
+                sh:node :NonLiteralMultilingualConvention;
+                sh:node :NonEmptyLiteralConvention
+            ]
+        );
+        sh:severity sh:Violation
+    ],
+    [
+        sh:path dcat:byteSize ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dcat_bytesize> ;
+        sh:message "La propiedad dcat:byteSize no puede tener más de un valor."@es ;
+        sh:message "The dcat:byteSize property cannot have more than one value."@en ;
+    ], 
+
+    # dcat:spatialResolutionInMeters
+    [
+        sh:path dcat:spatialResolutionInMeters ;
+        sh:nodeKind sh:Literal;
+        sh:or (
+            [ sh:datatype xsd:decimal ]
+            [ sh:datatype xsd:double ]
+        ) ;
+        sh:minInclusive 0;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dcat_spatialresolutioninmeters> ;
+        sh:message "La propiedad dcat:spatialResolutionInMeters debe ser un literal de tipo xsd:decimal o xsd:double."@es ;
+        sh:message "The property dcat:spatialResolutionInMeters must be a literal of type xsd:decimal or xsd:double."@en ;
+    ], 
+    [
+        sh:path dcat:spatialResolutionInMeters ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dcat_spatialresolutioninmeters> ;
+        sh:message "La propiedad dcat:spatialResolutionInMeters no puede tener más de un valor."@es ;
+        sh:message "The dcat:spatialResolutionInMeters property cannot have more than one value."@en ;
+    ], 
+
+    # dcat:temporalResolution
+    [
+        sh:path dcat:temporalResolution ;
+        sh:nodeKind sh:Literal;
+        sh:datatype xsd:duration ;
+        sh:node :DurationRestriction;
+    ],
+    [
+        sh:path dcat:temporalResolution ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dcat_temporalresolution> ;
+        sh:message "La propiedad dcat:temporalResolution no puede tener más de un valor."@es ;
+        sh:message "The dcat:temporalResolution property cannot have more than one value."@en ;
+    ], 
+
+    # spdx:checksum
+    [
+        sh:path spdx:checksum ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-spdx_checksum> ;
+        sh:message "El valor de spdx:checksum debe ser un IRI válido para spdx:checksum."@es ;
+        sh:message "The value of spdx:checksum must be a valid IRI for spdx:checksum."@en ;
+    ],
+    [
+        sh:path spdx:checksum ;
+        sh:class spdx:Checksum ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-spdx_checksum> ;
+    ],
+
+    # odrl:hasPolicy
+    [
+        sh:path odrl:hasPolicy ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-odrl_haspolicy> ;
+        sh:message "La propiedad odrl:hasPolicy no puede tener más de un valor."@es ;
+        sh:message "The odrl:hasPolicy property cannot have more than one value."@en ;
+    ], 
+    [
+        sh:path odrl:hasPolicy ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-odrl_haspolicy> ;
+        sh:message "El valor de odrl:hasPolicy debe ser un IRI válido para odrl:hasPolicy."@es ;
+        sh:message "The value of odrl:hasPolicy must be a valid IRI for odrl:hasPolicy."@en ;
+    ],
+
+    # dct:rights
+    [
+        sh:path dct:rights ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dct_rights> ;
+        sh:message "La propiedad dct:rights no puede tener más de un valor."@es ;
+        sh:message "The dct:rights property cannot have more than one value."@en ;
+    ], 
+    [
+        sh:path dct:rights ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dct_rights> ;
+        sh:message "El valor de dct:rights debe ser un IRI válido para dct:rights."@es ;
+        sh:message "The value of dct:rights must be a valid IRI for dct:rights."@en ;
+    ];
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#dcat-distribution> ;
+    sh:targetClass dcat:Distribution .
+
+# Convencion 02
+:DistributionSPALanguageRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que una distribución cumpla con las convenciones de idioma y contenido en español, incluyendo título, descripción y otros elementos clave."@es ;
+    rdfs:comment "Restriction to validate that a distribution complies with Spanish language and content conventions, including title, description, and other key elements."@en ;
+    rdfs:label "Restricción de distribución: idioma y contenido en español"@es ;
+    rdfs:label "Distribution restriction: Spanish language and content"@en ;
+    sh:name "Distribution Spanish Language and Content Restriction"@en ;
+    sh:name "Restricción de distribución: idioma y contenido en español"@es ;
+    sh:node :SpanishLanguageRestriction ;
+    sh:node :SpanishTitleRestriction ;
+    sh:node :SpanishDescriptionRestriction ;
+    sh:severity sh:Violation ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
+    sh:targetClass dcat:Distribution .
+
+# Convencion 21
+:OGCServiceAccessURLRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que las URLs de acceso a servicios OGC incluyan la operación GetCapabilities."@es ;
+    rdfs:comment "Restriction to validate that OGC service access URLs include the GetCapabilities operation."@en ;
+    rdfs:label "Restricción para URLs de acceso a servicios OGC"@es ;
+    rdfs:label "OGC Service Access URL Restriction"@en ;
+    sh:targetClass dcat:Distribution ;
+    sh:sparql [
+        sh:select """
+            PREFIX dcat: <http://www.w3.org/ns/dcat#>
+            PREFIX dct: <http://purl.org/dc/terms/>
+            
+            SELECT $this
+            WHERE {
+                $this dcat:accessURL ?accessURL .
+                
+                # Verifica si es un servicio OGC
+                {
+                    $this dct:conformsTo ?conformsTo .
+                    FILTER(
+                        ?conformsTo = <http://www.opengis.net/def/serviceType/ogc/wms> ||
+                        ?conformsTo = <http://www.opengis.net/def/serviceType/ogc/wfs> ||
+                        ?conformsTo = <http://www.opengis.net/def/serviceType/ogc/wcs> ||
+                        ?conformsTo = <http://www.opengis.net/def/serviceType/ogc/csw>
+                    )
+                } UNION {
+                    $this dct:format ?format .
+                    FILTER(
+                        ?format = <http://publications.europa.eu/resource/authority/file-type/WMS_SRVC> ||
+                        ?format = <http://publications.europa.eu/resource/authority/file-type/WFS_SRVC> ||
+                        ?format = <http://publications.europa.eu/resource/authority/file-type/WCS_SRVC> ||
+                        ?format = <http://publications.europa.eu/resource/authority/file-type/CSW_SRVC>
+                    )
+                }
+                
+                # Verifica si el accessURL NO tiene GetCapabilities
+                FILTER(!REGEX(STR(?accessURL), "[?&]request=GetCapabilities", "i"))
+            }
+        """ ;
+        sh:message "La URL de acceso de un servicio OGC debe incluir la operación GetCapabilities. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-21 | Ejemplo: http://example.org/wms?request=GetCapabilities&service=WMS"@es ;
+        sh:message "The access URL of an OGC service must include the GetCapabilities operation. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-21 | Example: http://example.org/wms?request=GetCapabilities&service=WMS"@en ;
+        sh:severity sh:Violation ;
+    ] ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-21> .
+
+#---------------------------
+# Other shape restrictions
+#---------------------------
+:Checksum_Shape
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que un recurso de tipo spdx:Checksum tenga un algoritmo definido y un valor de checksum válido."@es ;
+    rdfs:comment "Restriction to validate that a resource of type spdx:Checksum has a defined algorithm and a valid checksum value."@en ;
+    rdfs:label "Restricción de Checksum"@es ;
+    rdfs:label "Checksum Restriction"@en ;
+    sh:name "Checksum Validation"@en ;
+    sh:property 
+    # spdx:algorithm
+    [
+        sh:path spdx:algorithm ;
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-spdx_checksum> ;
+        sh:message "El algoritmo de checksum debe estar definido y ser único."@es ;
+        sh:message "The checksum algorithm must be defined and unique."@en ;
+    ], 
+    [
+        sh:path spdx:algorithm ;
+        sh:hasValue <http://spdx.org/rdf/terms#checksumAlgorithm_sha1> ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-spdx_checksum> ;
+        sh:message "El algoritmo de checksum debe ser SHA-1."@es ;
+        sh:message "The checksum algorithm must be SHA-1."@en ;
+    ], 
+    # spdx:checksumValue 
+    [
+        sh:path spdx:checksumValue ;
+        sh:node :NonEmptyLiteralConvention ;
+        sh:datatype xsd:hexBinary ;
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-spdx_checksum> ;
+        sh:message "El valor del checksum debe ser un literal no vacío de tipo xsd:hexBinary."@es ;
+        sh:message "The checksum value must be a non-empty literal of type xsd:hexBinary."@en ;
+    ] ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#spdx-checksum> ;
+    sh:targetClass spdx:Checksum .
+
+:IMT_Shape
+    a sh:NodeShape ;
+    rdfs:comment "Restricción heredada de NTI-RISP (2013) para validar que los valores de rdf:value y rdfs:label en recursos de tipo dct:IMT sean literales no vacíos y no multilingües."@es ;
+    rdfs:comment "Restriction inherited from NTI-RISP (2013) to validate that the values of rdf:value and rdfs:label in resources of type dct:IMT are non-empty, non-multilingual literals."@en ;
+    rdfs:label "Restricción para recursos de tipo dct:IMT"@es ;
+    rdfs:label "Restriction for dct:IMT resources"@en ;
+    sh:name "IMT Validation"@en ;
+    sh:property 
+    # rdf:value
+    [
+        sh:path rdf:value ;
+        sh:nodeKind sh:Literal ;
+        sh:node :NonLiteralMultilingualConvention ;
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path rdf:value ;
+        sh:node :NonEmptyLiteralConvention ;
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path rdf:value ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message "Debe haber al menos un valor para rdf:value."@es ;
+        sh:message "There must be at least one value for rdf:value."@en ;
+    ],
+    [
+        sh:path rdf:value ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message "Solo puede haber un valor para rdf:value."@es ;
+        sh:message "There can only be one value for rdf:value."@en ;
+    ],
+    # rdfs:label
+    [
+        sh:path rdfs:label ;
+        sh:nodeKind sh:Literal ;
+        sh:node :NonLiteralMultilingualConvention ;
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path rdfs:label ;
+        sh:node :NonEmptyLiteralConvention ;
+        sh:severity sh:Violation ;
+    ],
+    [
+        sh:path rdfs:label ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message "Debe haber al menos un valor para rdfs:label."@es ;
+        sh:message "There must be at least one value for rdfs:label."@en ;
+    ],
+    [
+        sh:path rdfs:label ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message "Solo puede haber un valor para rdfs:label."@es ;
+        sh:message "There can only be one value for rdfs:label."@en ;
+    ] ;
+    foaf:page <https://datosgobes.github.io/NTI-RISP/#distribucion_-_clase_dcatdistribution_-_obligatorio> ;
+    sh:targetClass dct:IMT .
+
+#--------------------------
+# Vocabulary restrictions
+#--------------------------
+:AvailabilityRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que el valor de dcatap:availability sea un IRI del vocabulario europeo de disponibilidad prevista."@es ;
+    rdfs:comment "Restriction to validate that the value of dcatap:availability is an IRI from the European planned availability vocabulary."@en ;
+    rdfs:label "Restricción de disponibilidad prevista"@es ;
+    rdfs:label "Planned Availability Restriction"@en ;
+
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^http://publications\\.europa\\.eu/resource/authority/planned-availability/.+$" ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dcatap_availability> ;
+    sh:message "El valor de dcatap:availability debe ser un IRI del vocabulario europeo de disponibilidad prevista: http://publications.europa.eu/resource/authority/planned-availability."@es ;
+    sh:message "The value of dcatap:availability must be an IRI from the European planned availability vocabulary: http://publications.europa.eu/resource/authority/planned-availability."@en ;
+    sh:severity sh:Violation .
+
+:FileTypeRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que el valor sea un IRI del vocabulario europeo de tipos de archivo."@es ;
+    rdfs:comment "Restriction to validate that the value is an IRI from the European file type vocabulary."@en ;
+    rdfs:label "Restricción de tipo de archivo"@es ;
+    rdfs:label "File Type Restriction"@en ;
+
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^http://publications\\.europa\\.eu/resource/authority/file-type/.+$" ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dct_format> ;
+    sh:message "El valor de dct:format debe ser un IRI del vocabulario europeo de tipos de archivo: http://publications.europa.eu/resource/authority/file-type."@es ;
+    sh:message "The value of dct:format must be an IRI from the European file type vocabulary: http://publications.europa.eu/resource/authority/file-type."@en ;
+    sh:severity sh:Violation .
+
+:IanaFormatRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que el valor sea un IRI válido que siga el formato de los tipos de medios definidos por IANA."@es ;
+    rdfs:comment "Restriction to validate that the value is a valid IRI following the format of media types defined by IANA."@en ;
+    rdfs:label "Restricción de formato IANA"@es ;
+    rdfs:label "IANA Format Restriction"@en ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^https?://www\\.iana\\.org/assignments/media-types/[a-z0-9!#$&^_.+-]+/[a-z0-9!#$&^_.+-]+$" ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-dcat_mediatype> ;
+    sh:message "El valor de dcat:mediaType debe ser un IRI válido del formato de tipos de medios de IANA."@es ;
+    sh:message "The value of dcat:mediaType must be a valid IRI from the IANA media types format."@en ;
+    sh:severity sh:Violation .
+
+:StatusRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para validar que el valor de adms:status sea un IRI del vocabulario europeo de estados de distribución."@es ;
+    rdfs:comment "Restriction to validate that the value of adms:status is an IRI from the European distribution status vocabulary."@en ;
+    rdfs:label "Restricción de estado de distribución"@es ;
+    rdfs:label "Distribution Status Restriction"@en ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^http://publications\\.europa\\.eu/resource/authority/distribution-status/.+$" ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-adms_status> ;
+    sh:message "El valor de adms:status debe ser un IRI del vocabulario europeo de estados de distribución: http://publications.europa.eu/resource/authority/distribution-status."@es ;
+    sh:message "The value of adms:status must be an IRI from the European distribution status vocabulary: http://publications.europa.eu/resource/authority/distribution-status."@en ;
+    sh:severity sh:Violation .

--- a/shacl/1.0.0/shacl_imports.ttl
+++ b/shacl/1.0.0/shacl_imports.ttl
@@ -1,0 +1,43 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcatapes: <https://datosgobes.github.io/DCAT-AP-ES/> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+
+<https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/shacl_imports.ttl>
+  rdf:type owl:Ontology ;
+  rdfs:label "Importaciones para DCAT-AP-ES"@es ;
+  rdfs:label "Imports for DCAT-AP-ES"@en ;
+  dcat:downloadURL <https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/shacl_mdr-vocabularies.shape.ttl> ;
+  dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE> ;
+  dct:conformsTo <https://www.w3.org/TR/shacl> ;
+  dct:description "Este archivo incluye las importaciones de las ontologías necesarias para el perfil de aplicación DCAT-AP-ES, apuntando a las serializaciones RDF requeridas por el validador del banco de pruebas ISA."@es ;
+  dct:description "This file includes the necessary ontology imports for the DCAT-AP-ES application profile, pointing to the RDF serializations required by the ISA testbed validator."@en ;
+  owl:versionInfo "1.0.0" ;
+  dct:modified "2024-04-08"^^xsd:date ;
+  dct:publisher <http://datos.gob.es/recurso/sector-publico/org/Organismo/E0DAT0001> ;
+  cc:attributionURL <https://datos.gob.es/> ;
+  dcatap:availability <http://data.europa.eu/r5r/stable> ;
+  foaf:homepage <https://datosgobes.github.io/DCAT-AP-ES/> ;
+  rdfs:comment "Este archivo proporciona las importaciones necesarias para las ontologías reutilizadas en el perfil de aplicación DCAT-AP-ES."@es ;
+  rdfs:comment "This file provides the necessary imports for the ontologies reused in the DCAT-AP-ES application profile."@en ;
+
+#--------------------------
+# Ontology imports
+#--------------------------
+  owl:imports <https://www.w3.org/ns/dcat2.ttl> ;
+  owl:imports <http://dublincore.org/2020/01/20/dublin_core_terms.ttl> ;
+  owl:imports <http://xmlns.com/foaf/spec/index.rdf> ;
+  owl:imports <https://www.w3.org/ns/locn.ttl> ;
+  owl:imports <https://spdx.org/rdf/terms/spdx-ontology.owl.xml> ;
+  owl:imports <https://schema.org/version/latest/schema.ttl> ;
+  owl:imports <http://www.w3.org/ns/prov-o.ttl> ;
+  owl:imports <http://www.w3.org/2006/time.ttl> ;
+  owl:imports <http://www.w3.org/2006/vcard/ns.ttl> ;
+  owl:imports <http://www.w3.org/ns/adms.ttl> 
+.

--- a/shacl/1.0.0/shacl_mdr-vocabularies.shape.ttl
+++ b/shacl/1.0.0/shacl_mdr-vocabularies.shape.ttl
@@ -1,0 +1,264 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix : <https://datosgobes.github.io/DCAT-AP-ES/> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix dcatapes: <https://datosgobes.github.io/DCAT-AP-ES/> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/shacl_mdr-vocabularies.shape.ttl>
+    rdfs:label "Restricciones de vocabularios para DCAT-AP-ES"@es ;
+    rdfs:label "Vocabulary restrictions for DCAT-AP-ES"@en ;
+    dcat:downloadURL <https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/shacl_mdr-vocabularies.shape.ttl> ;
+    dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE> ;
+    dct:conformsTo <https://www.w3.org/TR/shacl> ;
+    dct:description "Este documento especifica las restricciones en propiedades y clases expresadas por el modelo de metadatos DCAT-AP-ES en SHACL para los vocabularios controlados utilizados."@es ;
+    dct:description "This document specifies the constraints on properties and classes expressed by the DCAT-AP-ES application profile in SHACL for the controlled vocabularies used."@en ;
+    owl:versionInfo "1.0.0" ;
+    dct:modified "2024-04-08"^^xsd:date ;
+    dct:publisher <http://datos.gob.es/recurso/sector-publico/org/Organismo/E0DAT0001> ;
+    cc:attributionURL <https://datos.gob.es/> ;
+    dcatap:availability <http://data.europa.eu/r5r/stable> ;
+    foaf:homepage <https://datosgobes.github.io/DCAT-AP-ES/> ;
+    rdfs:seeAlso <https://datosgobes.github.io/DCAT-AP-ES/#dcat-ap-es-vocabularies> ;
+    rdfs:comment "Este archivo combina las restricciones SHACL con definiciones de las taxonomías y vocabularios controlados de DCAT-AP-ES."@es ;
+    rdfs:comment "This file combines SHACL constraints with definitions of taxonomies and controlled vocabularies of DCAT-AP-ES."@en .
+
+#--------------------------
+# Vocabulary restrictions
+#--------------------------
+:AtuRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción de unidad territorial administrativa"@es ;
+    rdfs:comment "Administrative territorial unit restriction"@en ;
+    rdfs:label "Restricción de unidad territorial administrativa"@es ;
+    rdfs:label "Administrative territorial unit restriction"@en ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^http://publications\\.europa\\.eu/resource/authority/atu/.+$" ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#dcat-ap-es-vocabularies> ;
+    sh:message "El valor debe ser un IRI del vocabulario europeo de Tipo de unidad territorial administrativa http://publications.europa.eu/resource/authority/atu"@es ;
+    sh:message "The value must be an IRI from the european Administrative territorial unit type vocabulary http://publications.europa.eu/resource/authority/atu"@en ;
+    sh:severity sh:Violation .
+
+:ContinentRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción de continente"@es ;
+    rdfs:comment "Continent restriction"@en ;
+    rdfs:label "Restricción de continente"@es ;
+    rdfs:label "Continent restriction"@en ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^http://publications\\.europa\\.eu/resource/authority/continent/.+$" ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#dcat-ap-es-vocabularies> ;
+    sh:message "El valor debe ser un IRI del vocabulario de continentes europeo http://publications.europa.eu/resource/authority/continent"@es ;
+    sh:message "The value must be an IRI from the European continent vocabulary http://publications.europa.eu/resource/authority/continent"@en ;
+    sh:severity sh:Violation .
+
+:CountryRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción de país"@es ;
+    rdfs:comment "Country restriction"@en ;
+    rdfs:label "Restricción de país"@es ;
+    rdfs:label "Country restriction"@en ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^http://publications\\.europa\\.eu/resource/authority/country/.+$" ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#dcat-ap-es-vocabularies> ;
+    sh:message "El valor debe ser un IRI del vocabulario de países europeo http://publications.europa.eu/resource/authority/country"@es ;
+    sh:message "The value must be an IRI from the European country vocabulary http://publications.europa.eu/resource/authority/country"@en ;
+    sh:severity sh:Violation .
+
+:AccessRightRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción de derechos de acceso"@es ;
+    rdfs:comment "Access Rights Restriction"@en ;
+    rdfs:label "Restricción de derechos de acceso"@es ;
+    rdfs:label "Access Rights Restriction"@en ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^http://publications\\.europa\\.eu/resource/authority/access-right/.+$" ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#dcat-ap-es-vocabularies> ;
+    sh:message "El valor debe ser un IRI del vocabulario de derechos de acceso europeo http://publications.europa.eu/resource/authority/access-right"@es ;
+    sh:message "The value must be an IRI from the European access right vocabulary http://publications.europa.eu/resource/authority/access-right"@en ;
+    sh:severity sh:Violation .
+
+:GeoNamesRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción de nombres geográficos"@es ;
+    rdfs:comment "Geo names restriction"@en ;
+    rdfs:label "Restricción de nombres geográficos"@es ;
+    rdfs:label "Geo names restriction"@en ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^https?://sws\\.geonames\\.org/[0-9]+/$" ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#dcat-ap-es-vocabularies> ;
+    sh:message "El valor debe ser un IRI del vocabulario de nombres geográficos http://sws.geonames.org"@es ;
+    sh:message "The value must be an IRI from the geonames http://sws.geonames.org"@en ;
+    sh:severity sh:Violation .
+
+:LanguageRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción de idioma"@es ;
+    rdfs:comment "Language Restriction"@en ;
+    rdfs:label "Restricción de idioma"@es ;
+    rdfs:label "Language Restriction"@en ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^http://publications\\.europa\\.eu/resource/authority/language/.+$" ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#dcat-ap-es-vocabularies> ;
+    sh:message "El valor de dct:language debe ser un IRI del vocabulario de idiomas europeo http://publications.europa.eu/resource/authority/language"@es ;
+    sh:message "The value of dct:language must be an IRI from the European language vocabulary http://publications.europa.eu/resource/authority/language"@en ;
+    sh:severity sh:Violation .
+
+:LicenceRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción de licencia"@es ;
+    rdfs:comment "Licence restriction"@en ;
+    rdfs:label "Restricción de licencia"@es ;
+    rdfs:label "Licence restriction"@en ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^http://publications.europa.eu/resource/authority/licence/.+$" ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#dcat-ap-es-vocabularies> ;
+    sh:message "El valor de dct:license debe ser un IRI del vocabulario de licencias europeo http://publications.europa.eu/resource/authority/licence"@es ;
+    sh:message "The value of dct:license must be an IRI from the European language vocabulary http://publications.europa.eu/resource/authority/licence"@en ;
+    sh:severity sh:Violation .
+
+:LicenceTypeRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción de tipo de licencia"@es ;
+    rdfs:comment "Licence type restriction"@en ;
+    rdfs:label "Restricción de tipo de licencia"@es ;
+    rdfs:label "Licence type restriction"@en ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^http://purl\\.org/adms/licencetype/[A-Z][A-Za-z0-9_-]{3,}$" ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#dcat-ap-es-vocabularies> ;
+    sh:message "El valor debe ser un IRI del vocabulario de tipos de licencia http://purl.org/adms/licencetype/1.0/"@es ;
+    sh:message "The value must be an IRI from the licence type vocabulary http://purl.org/adms/licencetype/1.0/"@en ;
+    sh:severity sh:Violation .
+
+:TerritoryRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción de territorio"@es ;
+    rdfs:comment "Territory restriction"@en ;
+    rdfs:label "Restricción de territorio"@es ;
+    rdfs:label "Territory restriction"@en ;
+    sh:nodeKind sh:IRI ;
+    sh:in (
+			<http://datos.gob.es/recurso/sector-publico/territorio/Pais/España>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Autonomia/Andalucia>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Almeria>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Cadiz>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Cordoba>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Granada>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Huelva>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Jaen>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Malaga>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Sevilla>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Autonomia/Aragon>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Huesca>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Teruel>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Zaragoza>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Autonomia/Principado-Asturias>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Asturias>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Autonomia/Illes-Balears>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Illes-Balears>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Autonomia/Canarias>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Las-Palmas>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Santa-Cruz-Tenerife>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Autonomia/Cantabria>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Cantabria>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Autonomia/Castilla-Leon>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Avila>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Burgos>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Leon>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Palencia>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Salamanca>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Segovia>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Soria>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Valladolid>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Zamora>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Autonomia/Castilla-La-Mancha>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Albacete>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Ciudad-Real>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Cuenca>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Guadalajara>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Toledo>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Autonomia/Cataluna>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Barcelona>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Girona>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Lleida>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Tarragona>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Autonomia/Comunitat-Valenciana>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Alicante>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Castellon>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Valencia>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Autonomia/Extremadura>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Badajoz>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Caceres>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Autonomia/Galicia>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/A-Coruna>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Lugo>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Ourense>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Pontevedra>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Autonomia/Comunidad-Madrid>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Madrid>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Autonomia/Region-Murcia>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Murcia>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Autonomia/Comunidad-Foral-Navarra>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Navarra>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Autonomia/Pais-Vasco>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Alava>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Guipuzcoa>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Vizcaya>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Autonomia/La-Rioja>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/La-Rioja>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Autonomia/Ceuta>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Ceuta>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Autonomia/Melilla>
+			<http://datos.gob.es/recurso/sector-publico/territorio/Provincia/Melilla>
+        ) ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#dcat-ap-es-vocabularies> ;
+    sh:message "El valor debe ser un IRI del vocabulario de territorios NTI-RISP http://datos.gob.es/recurso/sector-publico/territorio"@es ;
+    sh:message "The value must be an IRI from the NTI-RISP territory vocabulary http://datos.gob.es/recurso/sector-publico/territorio"@en ;
+    sh:severity sh:Violation .
+
+:PlaceRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción de lugar"@es ;
+    rdfs:comment "Place restriction"@en ;
+    rdfs:label "Restricción de lugar"@es ;
+    rdfs:label "Place restriction"@en ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^http://publications\\.europa\\.eu/resource/authority/place/.+$" ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#dcat-ap-es-vocabularies> ;
+    sh:message "El valor debe ser un IRI del vocabulario europeo de lugares http://publications.europa.eu/resource/authority/place"@es ;
+    sh:message "The value must be an IRI from the European place vocabulary http://publications.europa.eu/resource/authority/place"@en ;
+    sh:severity sh:Violation .
+
+# Convencion 01
+:DIR3OrganismRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción de organismo del sector público"@es ;
+    rdfs:comment "Public Sector Organism Restriction"@en ;
+    rdfs:label "Restricción de organismo del sector público"@es ;
+    rdfs:label "Public Sector Organism Restriction"@en ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^http://datos\\.gob\\.es/recurso/sector-publico/org/Organismo/[A-Z][A-Z0-9]{8}$" ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-01> ;
+    sh:message "El valor debe ser un IRI del vocabulario de organismos del sector público http://datos.gob.es/recurso/sector-publico/org/Organismo"@es ;
+    sh:message "The value must be an IRI from the public sector organism vocabulary http://datos.gob.es/recurso/sector-publico/org/Organismo"@en ;
+    sh:severity sh:Violation .
+
+:PublisherTypeRestriction
+    a sh:NodeShape ;
+    rdfs:comment "Restricción de tipo de editor"@es ;
+    rdfs:comment "Publisher type restriction"@en ;
+    rdfs:label "Restricción de tipo de editor"@es ;
+    rdfs:label "Publisher type restriction"@en ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^http://purl\\.org/adms/publishertype/[A-Z][A-Za-z0-9_()-]{5,}$" ;
+    foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#dcat-ap-es-vocabularies> ;
+    sh:message "El valor debe ser un IRI del vocabulario de tipos de editor http://purl.org/adms/publishertype/1.0"@es ;
+    sh:message "The value must be an IRI from the publisher type vocabulary http://purl.org/adms/publishertype/1.0"@en ;
+    sh:severity sh:Violation .

--- a/shacl/1.0.0/shacl_mdr_imports.ttl
+++ b/shacl/1.0.0/shacl_mdr_imports.ttl
@@ -1,0 +1,35 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcatapes: <https://datosgobes.github.io/DCAT-AP-ES/> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+
+<https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/shacl_mdr_imports.ttl>
+  rdf:type owl:Ontology ;
+  rdfs:label "Restricciones de vocabularios para DCAT-AP-ES"@es ;
+  rdfs:label "Vocabulary restrictions for DCAT-AP-ES"@en ;
+  dcat:downloadURL <https://datosgobes.github.io/DCAT-AP-ES/releases/1.0.0/shacl/shacl_mdr_imports.ttl> ;
+  dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE> ;
+  dct:conformsTo <https://www.w3.org/TR/shacl> ;
+  dct:description "Este archivo incluye las importaciones necesarias para las listas de códigos utilizadas en el perfil de aplicación DCAT-AP-ES."@es ;
+  dct:description "This file includes the necessary imports for the code lists used in the DCAT-AP-ES application profile."@en ;
+  owl:versionInfo "1.0.0" ;
+  dct:modified "2024-04-08"^^xsd:date ;
+  dct:publisher <http://datos.gob.es/recurso/sector-publico/org/Organismo/E0DAT0001> ;
+  cc:attributionURL <https://datos.gob.es/> ;
+  dcatap:availability <http://data.europa.eu/r5r/stable> ;
+  foaf:homepage <https://datosgobes.github.io/DCAT-AP-ES/> ;
+  rdfs:comment "Este archivo proporciona las importaciones de las listas de códigos recomendadas por el perfil de aplicación DCAT-AP-ES."@es ;
+  rdfs:comment "This file provides imports for the code lists recommended by the DCAT-AP-ES application profile."@en ;
+
+#--------------------------
+# Vocabulary imports
+#--------------------------
+  owl:imports <https://github.com/SEMICeu/DCAT-AP/raw/master/releases/2.1.1/dcat-ap_2.1.1.rdf> ;
+  owl:imports <https://github.com/SEMICeu/ADMS-AP/raw/master/purl.org/ADMS_SKOS_v1.00.rdf>
+.

--- a/shacl/README.md
+++ b/shacl/README.md
@@ -1,4 +1,4 @@
-# Guía de Validación SHACL para NTI-RISP
+# Guía de Validación SHACL para DCAT-AP-ES
 
 Este directorio contiene los archivos de validación SHACL ([Shapes Constraint Language](https://www.w3.org/TR/shacl/)) para [comprobar la conformidad](https://datos.gob.es/es/blog/shacl-un-lenguaje-para-validar-grafos-rdf) con el perfil de aplicación [DCAT-AP-ES](https://github.com/datosgobes/DCAT-AP-ES).
 


### PR DESCRIPTION
### Mejoras en la interfaz de usuario
* Se han añadido nuevas variables CSS (`--red-aporta`, `--red-aporta-light`, `--blue-aporta`) y una «cinta de borrador» para marcar versiones borrador en la interfaz de usuario, incluyendo estilos adaptables para pantallas pequeñas (`docs/assets/css/style.css`). [[1]](diffhunk://#diff-cb50d185ab39c19c3847ffd1445697194740357f7930b0d82d088ed03a1e1f00R13-R15) [[2]](diffhunk://#diff-cb50d185ab39c19c3847ffd1445697194740357f7930b0d82d088ed03a1e1f00R805-R839)
* Ajustado el color de fondo de los títulos de las admonitions para mejorar su visibilidad (`docs/assets/css/style.css`).

### Actualizaciones de la documentación
* Actualizada la terminología en las descripciones de vocabulario para mayor coherencia en inglés y español (`docs/index.en.md`, `docs/index.md`). [[1]](diffhunk://#diff-ee0a6e83cfdf2b20064ac437cb1944a135dfa856d49099583217977a46d216c5L63-R73) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L64-R74)

### Cambios de configuración
* Habilitado el modo borrador en la configuración y actualizadas las etiquetas y tooltips relacionadas con el borrador en `mkdocs.yml` (`mkdocs.yml`). [[1]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2L239-R239) [[2]](diffhunk: //#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2L350-R351) [[3]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2L489-R491)

### Actualizaciones de SHACL
* Habilitado el modo borrador en la configuración española y actualizadas las etiquetas y tooltips relacionadas con el borrador en `mkdocs.yml` (`mkdocs.yml`). https://github.com/datosgobes/DCAT-AP-ES/pull/40

### Ajustes de plantillas
* Se ha eliminado la lógica redundante de representación de la etiqueta de borrador de las modificaciones HTML y se ha centralizado la gestión de la cinta de borrador en `main.html` (`overrides/dcatapes/conventions_header.html`),