### PR TITLE
Actualizados SHACL 08/2025

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ refs/dcat-ap-es/*.docx
 docs/img/shacl_overview_validation.svg
 tools/.temp
 refs/github_issue_*.md
+shacl/dev

--- a/shacl/1.0.0/hvd/shacl_dataservice_hvd_shape.ttl
+++ b/shacl/1.0.0/hvd/shacl_dataservice_hvd_shape.ttl
@@ -56,43 +56,9 @@ dcatapes:DataService_HVD_Shape
     rdfs:label "HVD data service restrictions"@en ;
     foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#convencion-12> ;
     sh:closed false ;
-    sh:property
-    [ 
-    # dcatap:hvdCategory
-        sh:path dcatap:hvdCategory;
-        sh:nodeKind sh:IRI ;
-        sh:severity sh:Violation ;
-        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcatap_hvdcategory> ;
-        sh:message "El valor de dcatap:hvdCategory debe ser un IRI válido."@es ;
-        sh:message "The value of dcatap:hvdCategory must be a valid IRI."@en ;
-    ],
+    sh:property   
     [
-        sh:path dcatap:hvdCategory;
-        sh:node dcatapes:HVDCategoryRestriction ;
-    ],
-
-    # dcat:contactPoint
-    [
-        sh:path dcat:contactPoint ;
-        sh:minCount 1 ;
-        sh:severity sh:Violation ;
-        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcat_contactpoint> ;
-        sh:message "El servicio de datos HVD debe contener al menos un dcat:contactPoint."@es ;
-        sh:message "The HVD data service must contain at least one dcat:contactPoint."@en ;
-    ], 
-
-    # dcat:servesDataset
-    [
-        sh:path dcat:servesDataset ;
-        sh:minCount 1 ;
-        sh:severity sh:Violation ;
-        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcat_servesdataset> ;
-        sh:message "El servicio de datos HVD debe contener al menos un dcat:servesDataset."@es ;
-        sh:message "The HVD data service must contain at least one dcat:servesDataset."@en ;
-    ],
-    
-    # dcatap:applicableLegislation
-    [
+        # dcatap:applicableLegislation
         sh:path dcatap:applicableLegislation ;
         sh:nodeKind sh:IRI ;
         sh:severity sh:Violation ;
@@ -141,7 +107,15 @@ dcatapes:DataService_HVD_Shape
         sh:node dcatapes:HVDCategoryRestriction ;
         sh:severity sh:Violation ;
     ],
-
+    # dcat:contactPoint
+    [
+        sh:path dcat:contactPoint ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcat_contactpoint> ;
+        sh:message "El servicio de datos HVD debe contener al menos un dcat:contactPoint."@es ;
+        sh:message "The HVD data service must contain at least one dcat:contactPoint."@en ;
+    ], 
     # foaf:page
     [
         sh:path foaf:page ;
@@ -159,5 +133,38 @@ dcatapes:DataService_HVD_Shape
         foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-foaf_page> ;
         sh:message "El servicio de datos HVD debe contener al menos un foaf:page."@es ;
         sh:message "The HVD data service must contain at least one foaf:page."@en ;
+    ],
+    # dcat:servesDataset
+    [
+        sh:path dcat:servesDataset ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcat_servesdataset> ;
+        sh:message "El servicio de datos HVD debe contener al menos un dcat:servesDataset."@es ;
+        sh:message "The HVD data service must contain at least one dcat:servesDataset."@en ;
     ];
+    sh:targetClass dcat:DataService .
+
+dcatapes:DataService_HVD_Shape_legalInformation
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para la información legal de los datos HVD en DCAT-AP-ES"@es ;
+    rdfs:comment "Restriction for legal information of HVD data in DCAT-AP-ES"@en ;
+    rdfs:label "Restricción para la información legal de los datos HVD en DCAT-AP-ES"@es ;
+    rdfs:label "Restriction for legal information of HVD data in DCAT-AP-ES"@en ;
+    sh:name "Legal information for HVD data services"@en ;
+    sh:name "Información legal para servicios de datos HVD"@es ;
+    sh:or (
+		[
+  			sh:path dct:license;
+			sh:minCount 1 ;
+		]
+		[
+  			sh:path dct:accessRights;
+			sh:minCount 1 ;
+		]
+	) ; 
+    sh:severity sh:Violation ;
+    foaf:page <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd/#c3> ;
+    sh:message "It is mandatory to provide legal information (dct:license OR dct:rights)."@en ;
+    sh:message "Es obligatorio aportar información legal (dct:license O dct:rights)."@es ;
     sh:targetClass dcat:DataService .

--- a/shacl/1.0.0/hvd/shacl_distribution_hvd_shape.ttl
+++ b/shacl/1.0.0/hvd/shacl_distribution_hvd_shape.ttl
@@ -1,5 +1,6 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix cc: <http://creativecommons.org/ns#> .
+@prefix odrl:   <http://www.w3.org/ns/odrl/2/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
@@ -84,3 +85,31 @@ dcatapes:Distribution_HVD_Shape
         sh:message "The HVD distribution must contain a dcatap:applicableLegislation whose value is the ELI of the HVD Implementing Regulation: <http://data.europa.eu/eli/reg_impl/2023/138/oj>."@en ;
     ];
     sh:targetClass dcat:Distribution .
+
+dcatapes:Distribution_HVD_Shape_legalInformation
+    a sh:NodeShape ;
+    rdfs:comment "Restricción para la información legal de los datos HVD en DCAT-AP-ES"@es ;
+    rdfs:comment "Restriction for legal information of HVD data in DCAT-AP-ES"@en ;
+    rdfs:label "Restricción para la información legal de los datos HVD en DCAT-AP-ES"@es ;
+    rdfs:label "Restriction for legal information of HVD data in DCAT-AP-ES"@en ;
+    sh:name "Legal information for HVD distributions"@en ;
+    sh:name "Información legal para distribuciones HVD"@es ;
+    sh:or (
+		[
+  			sh:path dct:license;
+			sh:minCount 1 ;
+		]
+		[
+  			sh:path dct:rights;
+			sh:minCount 1 ;
+		]
+		[
+  			sh:path odrl:hasPolicy ;
+			sh:minCount 1 ;
+		]
+	) ; 
+    sh:severity sh:Violation ;
+    foaf:page <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd/#c3> ;
+    sh:message "It is mandatory to provide legal information (dct:license OR dct:rights)."@en ;
+    sh:message "Es obligatorio aportar información legal (dct:license O dct:rights O odrl:hasPolicy)."@es ;
+    sh:targetClass dcat:DataService .

--- a/shacl/1.0.0/shacl_catalog_shape.ttl
+++ b/shacl/1.0.0/shacl_catalog_shape.ttl
@@ -57,6 +57,7 @@ dcatapes:Catalog_Shape
     # dct:title
         sh:path dct:title ;
         sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
         sh:severity sh:Violation ;
         foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-dct_title> ;
         sh:message "El catálogo debe contener al menos un dct:title."@es ;
@@ -85,6 +86,7 @@ dcatapes:Catalog_Shape
     [
         sh:path dct:description ;
         sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
         sh:severity sh:Violation ;
         foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_catalog-dct_description> ;
         sh:message "El catálogo debe contener al menos un dct:description."@es ;
@@ -150,7 +152,7 @@ dcatapes:Catalog_Shape
         sh:or(
             [ 
                 sh:nodeKind sh:IRI;
-                sh:closed true
+                sh:closed true ;
             ]
             [
                 sh:nodeKind sh:BlankNodeOrIRI;
@@ -215,7 +217,6 @@ dcatapes:Catalog_Shape
             <http://publications.europa.eu/resource/authority/data-theme>
             <http://inspire.ec.europa.eu/theme>
             );
-        sh:description "Only the themes <http://datos.gob.es/kos/sector-publico/sector>, <http://publications.europa.eu/resource/authority/data-theme> and <http://inspire.ec.europa.eu/theme> can be present"@en ;
         sh:severity sh:Violation ;
         foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-11> ;
         sh:message "Sólo pueden estar presentes las taxonomías <http://datos.gob.es/kos/sector-publico/sector>, <http://publications.europa.eu/resource/authority/data-theme> y <http://inspire.ec.europa.eu/theme>. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-11"@es ;
@@ -236,8 +237,8 @@ dcatapes:Catalog_Shape
     [
         sh:path dct:issued ;
         sh:maxCount 1 ;
+        sh:node :DateOrDateTimeDataTypetConvention ;
         sh:nodeKind sh:Literal ;
-        sh:node dcatapes:DateOrDateTimeDataTypetConvention ;
         sh:severity sh:Violation ;
     ],
     [
@@ -306,6 +307,11 @@ dcatapes:Catalog_Shape
             [ sh:nodeKind sh:IRI ;]
         );
         sh:severity sh:Violation ;
+    ], 
+    [
+        sh:path dct:license;
+        sh:minCount 1 ;
+        sh:severity sh:Violation
     ], 
 
     # dcat:dataset
@@ -376,33 +382,41 @@ dcatapes:Catalog_Shape
         sh:message "El valor de dcat:record debe ser un IRI válido."@es ;
         sh:message "The value of dcat:record must be a valid IRI."@en ;
     ],
-
-    #dct:creator  
+    # dct:creator  
     [
         sh:path dct:creator ;
         sh:or(
-            [
-                sh:nodeKind sh:IRI; 
+            [   
+                sh:node dcatapes:DIR3OrganismRestriction ;  
+                sh:nodeKind sh:IRI ;
                 sh:closed true ;
             ]
             [
-                sh:nodeKind sh:BlankNodeOrIRI;
-                sh:node dcatapes:Agent_Shape;
-                sh:node dcatapes:CreatorAgentRestriction;
+                sh:nodeKind sh:BlankNodeOrIRI ;
+                sh:node dcatapes:Agent_Shape ;
+                sh:or(
+                    [
+                        sh:node :DIR3OrganismRestriction ;
+                        sh:node :PublisherAgentRestriction ;
+                    ]
+                    [
+                        sh:not :DIR3OrganismRestriction ;
+                        sh:node :CreatorAgentRestriction ;
+                    ]
+                );
             ]
-        );
-        sh:severity sh:Violation ;
+        ); 
     ],
     [
         sh:path dct:creator ;
         sh:or(
             [ 
-                sh:nodeKind sh:IRI;
-                sh:closed true
+                sh:nodeKind sh:IRI ;
+                sh:closed true ;
             ]
             [
-                sh:nodeKind sh:BlankNodeOrIRI;
-                sh:node dcatapes:Agent_ShapeRecommended
+                sh:nodeKind sh:BlankNodeOrIRI ;
+                sh:node dcatapes:Agent_ShapeRecommended ;
             ]
         );
         sh:severity sh:Warning ;

--- a/shacl/1.0.0/shacl_dataservice_shape.ttl
+++ b/shacl/1.0.0/shacl_dataservice_shape.ttl
@@ -80,40 +80,6 @@ dcatapes:DataService_Shape
         sh:message "Más de un valor comparten la misma etiqueta de idioma. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@es ;
         sh:message "More than one value shares the same language tag. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@en ;
     ],
-
-    # dcat:endpointURL
-    [
-        sh:path dcat:endpointURL ;
-        sh:nodeKind sh:IRI ;
-        sh:severity sh:Violation ;
-        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcat_endpointurl> ;
-        sh:message "El valor de dcat:endpointURL debe ser un IRI válido."@es ;
-        sh:message "The value of dcat:endpointURL must be a valid IRI."@en ;
-    ],
-    [
-        sh:path dcat:endpointURL ;
-        sh:minCount 1 ;
-        sh:severity sh:Violation ;
-        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcat_endpointurl> ;
-        sh:message "El servicio de datos debe contener al menos un dcat:endpointURL."@es ;
-        sh:message "The data service must contain at least one dcat:endpointURL."@en ;
-    ], 
-
-    # dcatap:hvdCategory
-    [
-        sh:path dcatap:hvdCategory;
-        sh:nodeKind sh:IRI ;
-        sh:severity sh:Violation ;
-        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcatap_hvdcategory> ;
-        sh:message "El valor de dcatap:hvdCategory debe ser un IRI válido."@es ;
-        sh:message "The value of dcatap:hvdCategory must be a valid IRI."@en ;
-    ],
-    [
-        sh:path dcatap:hvdCategory;
-        sh:node dcatapes:HVDCategoryRestriction ;
-        sh:severity sh:Violation ;
-    ],
-
     # dcat:contactPoint
     [
         sh:path dcat:contactPoint ;
@@ -158,39 +124,7 @@ dcatapes:DataService_Shape
         sh:message "The data service should contain at least one foaf:page."@en ;
     ], 
 
-    # dcat:theme
-    [
-        sh:path dcat:theme ;
-        sh:minCount 1 ;
-        sh:severity sh:Violation ;
-        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcat_theme> ;
-        sh:message "El servicio de datos debe contener al menos un dcat:theme."@es ;
-        sh:message "The data service must contain at least one dcat:theme."@en ;
-    ], 
-    [
-		sh:path dcat:theme ;
-	    sh:qualifiedValueShape [
-			sh:node dcatapes:PublicSectorRestriction ;
-		];	
-        sh:qualifiedMinCount 1;
-        sh:severity sh:Violation
-    ],
-    [
-        sh:path dcat:theme ;
-        sh:nodeKind sh:IRI ;
-        sh:or(
-            [   
-                sh:node dcatapes:PublicSectorRestriction ;
-            ]
-            [   
-                sh:node dcatapes:EuropeanDataThemeRestriction ;
-            ]
-            [
-                sh:node dcatapes:InspireDataThemeRestriction ;
-            ]
-        );
-        sh:severity sh:Violation
-    ],
+
 
     # dct:publisher
     [
@@ -245,7 +179,56 @@ dcatapes:DataService_Shape
         sh:message "El valor de dct:publisher debe ser un IRI o un nodo en blanco que cumpla con las restricciones de la forma de agente."@es ;
         sh:message "The value of dct:publisher must be an IRI or a blank node that meets the agent shape restrictions."@en ;
     ],
-
+    # dcat:theme
+    [
+        sh:path dcat:theme ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcat_theme> ;
+        sh:message "El servicio de datos debe contener al menos un dcat:theme."@es ;
+        sh:message "The data service must contain at least one dcat:theme."@en ;
+    ], 
+    [
+		sh:path dcat:theme ;
+	    sh:qualifiedValueShape [
+			sh:node dcatapes:PublicSectorRestriction ;
+		];	
+        sh:qualifiedMinCount 1;
+        sh:severity sh:Violation
+    ],
+    [
+        sh:path dcat:theme ;
+        sh:nodeKind sh:IRI ;
+        sh:or(
+            [   
+                sh:node dcatapes:PublicSectorRestriction ;
+            ]
+            [   
+                sh:node dcatapes:EuropeanDataThemeRestriction ;
+            ]
+            [
+                sh:node dcatapes:InspireDataThemeRestriction ;
+            ]
+        );
+        sh:severity sh:Violation
+    ],
+    # dcat:endpointURL
+    [
+        sh:path dcat:endpointURL ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcat_endpointurl> ;
+        sh:message "El valor de dcat:endpointURL debe ser un IRI válido."@es ;
+        sh:message "The value of dcat:endpointURL must be a valid IRI."@en ;
+    ],
+    [
+        sh:path dcat:endpointURL ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataservice-dcat_endpointurl> ;
+        sh:message "El servicio de datos debe contener al menos un dcat:endpointURL."@es ;
+        sh:message "The data service must contain at least one dcat:endpointURL."@en ;
+    ],
     # dcat:endpointDescription
     [
         sh:path dcat:endpointDescription ;
@@ -376,6 +359,11 @@ dcatapes:DataService_Shape
         sh:message "El valor de dcat:keyword ser un Literal."@es ;
         sh:message "The value of dcat:keyword must be a Literal."@en ;
     ],
+    [
+        sh:path dcat:keyword ;
+        sh:minCount 1 ;
+        sh:severity sh:Warning
+    ], 
     [
         sh:path dcat:keyword ;
         sh:node dcatapes:LiteralMultilingualConvention ; 

--- a/shacl/1.0.0/shacl_dataset_shape.ttl
+++ b/shacl/1.0.0/shacl_dataset_shape.ttl
@@ -65,6 +65,7 @@ dcatapes:Dataset_Shape
     # dct:title
         sh:path dct:title ;
         sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
         sh:severity sh:Violation ;
         foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_title> ;
         sh:message "El conjunto de datos debe contener al menos un dct:title."@es ;
@@ -222,7 +223,15 @@ dcatapes:Dataset_Shape
         sh:message "El valor de dcat:distribution debe ser un dcat:Distribution."@es ;
         sh:message "The value of dcat:distribution must be a dcat:Distribution."@en ;
     ], 
-
+    # Convención 23
+    [
+        sh:path dcat:distribution ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-23> ;
+        sh:message "Todo recurso de tipo dcat:Dataset debe contener al menos una instancia de dcat:Distribution. Ver: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-23"@es ;
+        sh:message "All dcat:Dataset resources must contain at least one instance of dcat:Distribution. See: https://datosgobes.github.io/DCAT-AP-ES/conventions/#convencion-23"@en .
+    ], 
     # dcat:keyword
     [
         sh:path dcat:keyword ;
@@ -232,6 +241,7 @@ dcatapes:Dataset_Shape
         sh:message "El valor de dcat:keyword ser un Literal."@es ;
         sh:message "The value of dcat:keyword must be a Literal."@en ;
     ],
+
     [
         sh:path dcat:keyword ;
         sh:node dcatapes:LiteralMultilingualConvention ; 
@@ -336,32 +346,41 @@ dcatapes:Dataset_Shape
         sh:message "The value of adms:identifier must be a adms:Identifier."@en ;
     ], 
 
-    #dct:creator  
+    # dct:creator  
     [
         sh:path dct:creator ;
         sh:or(
-            [
-                sh:nodeKind sh:IRI; 
+            [   
+                sh:node dcatapes:DIR3OrganismRestriction ;  
+                sh:nodeKind sh:IRI ;
                 sh:closed true ;
             ]
             [
-                sh:nodeKind sh:BlankNodeOrIRI;
-                sh:node dcatapes:Agent_Shape;
-                sh:node dcatapes:CreatorAgentRestriction;
+                sh:nodeKind sh:BlankNodeOrIRI ;
+                sh:node dcatapes:Agent_Shape ;
+                sh:or(
+                    [
+                        sh:node :DIR3OrganismRestriction ;
+                        sh:node :PublisherAgentRestriction ;
+                    ]
+                    [
+                        sh:not :DIR3OrganismRestriction ;
+                        sh:node :CreatorAgentRestriction ;
+                    ]
+                );
             ]
-        );
-        sh:severity sh:Violation ;
+        ); 
     ],
     [
         sh:path dct:creator ;
         sh:or(
             [ 
-                sh:nodeKind sh:IRI;
+                sh:nodeKind sh:IRI ;
                 sh:closed true
             ]
             [
-                sh:nodeKind sh:BlankNodeOrIRI;
-                sh:node dcatapes:Agent_ShapeRecommended
+                sh:nodeKind sh:BlankNodeOrIRI ;
+                sh:node dcatapes:Agent_ShapeRecommended ;
             ]
         );
         sh:severity sh:Warning ;
@@ -477,7 +496,15 @@ dcatapes:Dataset_Shape
         sh:message "El valor de dct:accrualPeriodicity debe ser un IRI de los vocabularios permitidos o un Literal de tipo xsd:duration."@es ;
         sh:message "The value of dct:accrualPeriodicity must be an IRI from the allowed vocabularies or a Literal of type xsd:duration."@en ;
     ],
-
+    [
+        sh:path dct:accrualPeriodicity ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_accrualperiodicity> ;
+        sh:message "La propiedad dct:accrualPeriodicity no puede tener más de un valor."@es ;
+        sh:message "The dct:accrualPeriodicity property cannot have more than one value."@en ;
+    ],
+    ],
     # dcat:version
     [
         sh:path dcat:version ;
@@ -523,12 +550,29 @@ dcatapes:Dataset_Shape
         sh:uniqueLang true;
         sh:severity sh:Violation ;
         foaf:page <https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02> ;
-        sh:message "Más de un valor comparten la misma etiqueta de idioma. Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@es ;
-        sh:message "More than one value shares the same language tag. See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@en ;
+        sh:message "Las notas de la versión debe tener al menos un valor en español (etiqueta de idioma 'es'). Ver: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@es ;
+        sh:message "The version notes must have at least one value in Spanish (language tag 'es') See: https://datosgobes.github.io/DCAT-AP-ES/convenciones/#convencion-02"@en ;
+    [
+        sh:path adms:versionNotes ;
+        sh:uniqueLang true;
+        sh:severity sh:Violation ;
+        sh:sparql [
+            sh:message "The version notes value must be at least in Spanish."@en ;
+            sh:select """
+                PREFIX adms: <http://www.w3.org/ns/adms#>
+                SELECT $this
+                WHERE {
+                FILTER EXISTS { $this adms:versionNotes ?value }
+
+                FILTER NOT EXISTS {
+                    $this adms:versionNotes ?value .
+                    FILTER(isLiteral(?value) && LANG(?value) = "es")
+                }
+            }
+            """ ;
+        ] ;
     ],
-
     # dcat:hasVersion
-
     [
         sh:path dct:hasVersion ;
         sh:nodeKind sh:IRI; 
@@ -600,7 +644,7 @@ dcatapes:Dataset_Shape
     # dct:isReferencedBy
     [
         sh:path dct:isReferencedBy ;
-        sh:nodeKind sh:IRI; 
+        sh:nodeKind sh:IRI ; 
         sh:severity sh:Violation ;
         foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_isreferencedby> ;
         sh:message "El valor de dct:isReferencedBy debe ser un IRI válido."@es ;
@@ -663,7 +707,7 @@ dcatapes:Dataset_Shape
     # dct:source
     [
         sh:path dct:source ;
-        sh:nodeKind sh:IRI; 
+        sh:nodeKind sh:IRI ; 
         sh:severity sh:Violation ;
         foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_dataset-dct_source> ;
         sh:message "El valor de dct:source debe ser un IRI válido."@es ;

--- a/shacl/1.0.0/shacl_distribution_shape.ttl
+++ b/shacl/1.0.0/shacl_distribution_shape.ttl
@@ -462,13 +462,22 @@ dcatapes:Distribution_Shape
         sh:message "La propiedad dcat:temporalResolution no puede tener más de un valor."@es ;
         sh:message "The dcat:temporalResolution property cannot have more than one value."@en ;
     ], 
-
     # spdx:checksum
+    [
+        sh:path spdx:checksum ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-spdx_checksum> ;
+        sh:message "La propiedad spdx:checksum no puede tener más de un valor."@es ;
+        sh:message "The spdx:checksum property cannot have more than one value."@en ;
+    ], 
     [
         sh:path spdx:checksum ;
         sh:class spdx:Checksum ;
         sh:severity sh:Violation ;
         foaf:page <https://datosgobes.github.io/DCAT-AP-ES/#nota-dcat_distribution-spdx_checksum> ;
+        sh:message "La propiedad spdx:checksum debe ser una entidad spdx:Checksum."@es ;
+        sh:message "The spdx:checksum property must be an spdx:Checksum entity."@en ;
     ],
 
     # odrl:hasPolicy


### PR DESCRIPTION
-  Se han actualizado los archivos de formas SHACL para catálogos, datasets, servicios de datos y distribuciones, principalmente para: 
   - Añadir restricciones de tipo de nodo (`sh:nodeKind sh:Literal`) en títulos y descripciones. 
   -  Mejorar la validación de propiedades obligatorias y cardinalidades máximas. - Añadir o ajustar restricciones para propiedades como `dcat:distribution`, `dct:creator`, `dct:accrualPeriodicity`, `spdx:checksum`, entre otras. 
   - Mejorar los mensajes de error y advertencia, y la documentación de las restricciones.
- HVD: Actualizadas las restricciones SHACL para los servicios de datos y distribuciones HVD, incluyendo información legal y validaciones adicionales.