### PR TITLE
Convencion 24  - Relación explícita con metadatos fuente mediante `adms:identifier`

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -48,6 +48,7 @@ Estas convenciones aseguran la coherencia en la descripción de los recursos, ga
 - [**Convención 21**](#convencion-21): En las distribuciones de servicios OGC, las URLs de acceso *DEBEN* modelarse de la siguiente manera: En `dcat:accessURL`: URL completa de la petición de capacidades del servicio `GetCapabilities` (ej: `http://example.org/wms?request=GetCapabilities&service=WMS`) y en `dct:conformsTo`: URL del estándar OGC correspondiente, ej: `http://www.opengeospatial.org/standards/wms`
 - [**Convención 22**](#convencion-22): Los periodos temporales *DEBEN* ser descritos exclusivamente mediante las propiedades `dcat:startDate` y `dcat:endDate` dentro de `dct:temporal`. El intervalo también puede ser abierto, es decir, puede tener solo un comienzo o solo un final.
 - [**Convención 23**](#convencion-23): Los *datasets* *DEBEN* incluir al menos una distribución (`dcat:Distribution`).
+- [**Convención 24**](#convencion-24): Cuando un recurso DCAT-AP-ES derive de un metadato fuente de otro estándar (por ejemplo: INSPIRE/ISO19139, MARC21, DataCite, EML, Dublin Core, etc.), *DEBERÍA* incluirse una relación mediante la propiedad `adms:identifier` que apunte al identificador persistente del metadato fuente, utilizando un nodo de tipo `adms:Identifier`.
 
 # Convenciones generales {#general}
 
@@ -413,6 +414,27 @@ Obligatoriedad temporal de distribuciones en los datasets
     ```turtle linenums="1"
     --8<-- "examples/ttl/Conventions_dataset-dcat-distribution.ttl"
     ```
+
+## Relación explícita con metadatos fuente mediante `adms:identifier` {#dataset-metadata-relation}
+La federación y migración de metadatos desde diferentes perfiles y estándares (INSPIRE/ISO19139, MARC21, DataCite, EML, Dublin Core, etc.) hacia DCAT-AP-ES genera la necesidad de enlazar los metadatos fuente con los recursos DCAT-AP-ES generados. Establecer una convención clara facilita la trazabilidad, la interoperabilidad semántica y la gestión eficiente de versiones en procesos de migración y federación entre diferentes modelos de metadatos.
+
+!!! should technical "Convención 24"
+    Cuando un recurso DCAT-AP-ES derive de un metadato fuente de otro estándar (por ejemplo: INSPIRE/ISO19139, MARC21, DataCite, EML, Dublin Core, etc.), **DEBERÍA** incluirse una relación mediante la propiedad `adms:identifier` que apunte al identificador persistente del metadato fuente, utilizando un nodo de tipo `adms:Identifier`.
+
+!!! info "Ejemplo de un dataset relacionado con un servicio OGC INSPIRE"
+    ```turtle linenums="1"
+    --8<-- "examples/ttl/Conventions_dataset-metadata-relation.ttl"
+    ```
+
+!!! warning "Importante"
+    - La URI referenciada en la propiedad `adms:identifier` debe ser persistente y resoluble, preferentemente el identificador completo del metadato fuente.
+    - La clase [`adms:Identifier`](https://www.w3.org/TR/vocab-adms/#identifier) requiere proporcionar `skos:notation`, con un tipo de dato que especifique el esquema de identificación (incluyendo el número de versión si es apropiado).
+    - Esta convención no impide el uso de otras propiedades de relación (`dct:relation`, `rdfs:seeAlso`, `dcat:qualifiedRelation`) si se requiere mayor granularidad o complementariedad.
+    - El uso de `adms:Identifier` como nodo informativo permite enriquecer el enlace para hacerlo más usable en vistas de metadatos de catálogos o para reutilizadores externos.
+
+!!! info "Nota sobre implementación"
+    - Usar `adms:identifier` permite incluir propiedades contextuales adicionales sobre el identificador secundario (estándar de conformidad, formato, página de visualización, etc.).
+    - Referencia: [Best practices for linking DCAT-AP datasets to alternative metadata descriptions (SEMICeu/DCAT-AP#450)](https://github.com/SEMICeu/DCAT-AP/issues/450)
 
 # Convenciones para `dcat:Distribution` {#distribution}
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ Se enumeran a continuación las clases más relevantes utilizadas en el modelo:
 * [**Conjunto de datos**](#Dataset). La clase Conjunto de Datos ([**`dcat:Dataset`**](http://www.w3.org/ns/dcat#Dataset)) representa una conceptualización de una colección de información publicada por un único agente identificable. La noción de conjunto de datos es amplia con la intención de dar cabida a los tipos de recursos que surgen de un contexto de publicación pudiendo representarse de muchas formas, incluidos números, texto, imágenes, sonido y otros medios o tipos, cualquiera de los cuales podría recopilarse en un conjunto de datos.
 * [**Distribución**](#Distribution). La clase Distribución de un conjunto de datos ([**`dcat:Distribution`**](http://www.w3.org/ns/dcat#Distribution)) representa una forma accesible y reutilizable de un conjunto de datos, como un archivo descargable.
 * [**Agente**](#Agent). La clase Agent ([**`foaf:Agent`**](http://xmlns.com/foaf/0.1/Agent)) se utiliza para representar cualquier organización o persona que posee competencias para realizar actuaciones sobre un catálogo y los recursos catalogados. Su función principal es proporcionar referencias concretas sobre los diferentes actores que pueden intervenir con diferentes roles en la gestión de un catálogo de datos.
-* [**Identificador**](#Identifier). La clase Identificador de un conjunto de datos ([**`adms:Identifier`**](http://www.w3.org/ns/adms#Identifier)) se utiliza para expresar la referencia exclusiva asignada a un conjunto de datos en el contexto de un esquema de identificadores determinado.
+* [**Identificador**](#Identifier). La clase Identificador (alternativo) de un conjunto de datos ([**`adms:Identifier`**](https://www.w3.org/TR/vocab-adms/#identifier)) se utiliza para expresar la referencia exclusiva asignada a un conjunto de datos en el contexto de un esquema de identificadores determinado.
 * [**Localización**](#Location). La clase Localización ([**`dct:Location`**](http://purl.org/dc/terms/Location)), se emplea para identificar una región geográfica o un lugar. Se puede representar utilizando un vocabulario controlado o mediante la expresión de coordenadas geográficas que delimitan un área específica.
 * [**Vigencia**](#PeriodOfTime). La clase Vigencia o Período Temporal ([**`dct:PeriodOfTime`**](http://purl.org/dc/terms/PeriodOfTime)) se utiliza para definir un intervalo de tiempo que se delimita por una fecha de inicio y otra de finalización.
 * [**Control y verificación de integridad**](#Checksum). La clase Control y Verificación de recursos ([**`spdx:Checksum`**](http://spdx.org/rdf/terms#Checksum)) se utiliza para especificar el método que se implementa y el resultado obtenido para garantizar la integridad de las distribuciones de conjuntos de datos, es decir, que su contenido no ha sido alterado.
@@ -263,6 +263,12 @@ Igualmente, se indica para cada entidad del modelo -catálogo, registro, servici
 | Nombre | Nombre del agente | [name](#Agent.name) | Ob | 1..n | [**rdfs:Literal**](http://www.w3.org/2000/01/rdf-schema#Literal) |
 | Identificador | Identificador del agente | [identifier](#Agent.identifier) | R | 0..1 | [**rdfs:Literal**](http://www.w3.org/2000/01/rdf-schema#Literal) |
 | Tipo | Tipo de agente | [type](#Agent.type) | R | 0..1 | [**skos:Concept**](http://www.w3.org/2004/02/skos/core#Concept) |
+
+## Identificador - Clase: adms:Identifier - Opcional {#Identifier}
+
+| Metadato | Descripción | Propiedad | T | C | Rango |
+| --- | --- | --- | --- | --- | --- |
+| Notación | Identificador alternativo basado en la clase de identificadores UN/CEFACT. | [notation](#Identifier.notation) | Ob | 1 | [**rdfs:Literal**](http://www.w3.org/2000/01/rdf-schema#Literal) |
 
 
 ## Localización - Clase: dct:Location - Opcional {#Location}
@@ -1953,6 +1959,30 @@ Para su implementación, se pueden utilizar las siguientes propiedades recomenda
 
     El rango de esta propiedad es genérico (`rdfs:Literal`) para poder expresar la geometría utilizando diferentes codificaciones. Por ejemplo, se puede expresar indicando la secuencia de coordenadas geográficas (Longitud y Latitud) que delimitan la región geográfica que se describe.
 
+## Metadatos de la clase Identificador {#adms-Identifier}
+
+La clase Identificador (alternativo) de un conjunto de datos `adms:Identifier` se utiliza para expresar la referencia exclusiva asignada a un conjunto de datos en el contexto de un esquema de identificadores determinado.
+
+Para su implementación, se debe utilizar la siguiente propiedad obligatoria:
+
+* Para referir la cadena que representa al identificador, debe usarse la propiedad `skos:notation`.
+
+| [`adms:Identifier`](#Identifier) | [`skos:notation`](http://www.w3.org/2004/02/skos/core#notation) |
+| --- | --- |
+| **Metadato** | **Notación** |
+| **Descripción** | Una cadena que es un identificador en el contexto del esquema de identificadores al que hace referencia su tipo de datos. Esto se basa en la clase de identificadores UN/CEFACT. |
+| **Propiedad** | [**skos:notation**](http://www.w3.org/2004/02/skos/core#notation) |
+| **Aplicabilidad** | **Obligatorio** |
+| **Cardinalidad** | **1..1** |
+| **Rango** | [**rdfs:Literal**](http://www.w3.org/2000/01/rdf-schema#Literal) |
+
+!!! note "Nota de uso"
+
+    Un identificador en un contexto concreto, compuesto por:
+    - la cadena de contenido que constituye el identificador;
+    - un identificador opcional para el esquema de identificadores;
+    - un identificador opcional para la versión del esquema de identificadores;
+    - un identificador opcional para la agencia que gestiona el esquema de identificadores.
 
 ## Metadatos de la clase Período temporal {#dct-Periodoftime}
 

--- a/examples/ttl/Conventions_dataset-metadata-relation.ttl
+++ b/examples/ttl/Conventions_dataset-metadata-relation.ttl
@@ -1,0 +1,28 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Dataset en DCAT-AP-ES
+<http://datos.gob.es/recurso/dataset/123>
+    a dcat:Dataset ;
+    dct:title "Dataset geográfico de ejemplo"@es ;
+    dct:identifier <http://datos.gob.es/recurso/dataset/123> ;
+    
+    # Identificador INSPIRE con contexto adicional
+    adms:identifier <http://www.idee.es/csw-codsi-idee/ES-INSPIRE-456> .
+
+# Descripción del identificador INSPIRE
+<http://www.idee.es/csw-codsi-idee/ES-INSPIRE-456>
+    a adms:Identifier ;
+    skos:notation "ES-INSPIRE-456" ;
+    dct:identifier <http://www.idee.es/csw-codsi-idee/ES-INSPIRE-456> ;
+    rdfs:comment "Identificador INSPIRE del mismo dataset"@es ;
+    
+    # Propiedades contextuales adicionales
+    dct:conformsTo <http://data.europa.eu/eli/reg/2008/1205> ;  # Reglamento de Metadatos INSPIRE
+    foaf:page <http://geonetwork.example.org/metadata/ES-INSPIRE-456> ;  # Página HTML de visualización
+    dct:format <http://publications.europa.eu/resource/authority/file-type/XML> ;
+    dct:issued "2020-01-15"^^xsd:date .


### PR DESCRIPTION
- Actualizar conventions para incluir convencion 24.
- Añadir ejemplos de uso para convencion 24.
- Añadida clase Identifier explicitamente en el modelo.