### PR TITLE
fix: validar ejemplo completo E_DCAT-AP-ES_full_optional

### DIFF
--- a/examples/rdf/1.0.0/E_DCAT-AP-ES_full_optional.rdf
+++ b/examples/rdf/1.0.0/E_DCAT-AP-ES_full_optional.rdf
@@ -24,25 +24,9 @@
     <dc:license rdf:resource="http://publications.europa.eu/resource/authority/licence/CC_BY_4_0"/>
     <dc:spatial rdf:resource="http://datos.gob.es/recurso/sector-publico/territorio/Pais/España"/>
     <dcat:catalog rdf:resource="http://dcat-ap-es.ejemplo.org/catalogo_relacionado"/>
-    <dcat:record>
-      <dcat:CatalogRecord>
-        <foaf:primaryTopic rdf:resource="http://dcat-ap-es.ejemplo.org/catalogo"/>
-        <dc:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-01-02T12:00:00+01:00</dc:modified>
-        <dc:conformsTo rdf:resource="http://datos.gob.es/es/documentacion/DCAT-AP-ES"/>
-        <dc:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2022-01-01T12:00:00+01:00</dc:issued>
-        <adms:status rdf:resource="http://purl.org/adms/status/Completed"/>
-        <dc:title xml:lang="es">Registro del Catálogo de Datos Abiertos</dc:title>
-        <dc:description xml:lang="es">Registro de metadatos del Catálogo de Datos Abiertos de ejemplo</dc:description>
-      </dcat:CatalogRecord>
-    </dcat:record>
+    <dcat:record rdf:resource="http://dcat-ap-es.ejemplo.org/catalogo/record/dataset-ejemplo-1"/>
 
-    <dc:creator>
-      <foaf:Organization>
-        <foaf:name>Nombre del departamento del organismo</foaf:name>
-        <dc:identifier>E0DAT0001</dc:identifier>
-        <dc:type rdf:resource="http://purl.org/adms/publishertype/NationalAuthority"/>
-      </foaf:Organization>
-    </dc:creator>
+    <dc:creator rdf:resource="http://datos.gob.es/recurso/sector-publico/org/Organismo/E0DAT0001"/>
 
     <dc:hasPart rdf:resource="http://dcat-ap-es.ejemplo.org/catalogo-vinculado"/>
     <dc:isPartOf rdf:resource="http://dcat-ap-es.ejemplo.org/catalogo-delqueformaparte"/>
@@ -108,6 +92,7 @@
 
         <dcat:distribution>
           <dcat:Distribution rdf:about="http://dcat-ap-es.ejemplo.org/catalogo-vinculado/distribucion/ejemplo">
+            <dc:title xml:lang="es">Distribución de ejemplo en formato CSV</dc:title>
             <dcat:accessURL rdf:resource="http://dcat-ap-es.ejemplo.org/catalogo-vinculado/files/ejemplo.csv"/>
             <dcatap:applicableLegislation rdf:resource="http://data.europa.eu/eli/dir/2007/2/2019-06-26"/>
             <dc:description xml:lang="es">Descripción de una distribución distribuida de ejemplo</dc:description>
@@ -424,5 +409,15 @@
     <dc:license rdf:resource="http://publications.europa.eu/resource/authority/licence/CC_BY_4_0"/>
     <dcat:keyword xml:lang="es">estadísticas</dcat:keyword>
   </dcat:DataService>
+
+  <dcat:CatalogRecord rdf:about="http://dcat-ap-es.ejemplo.org/catalogo/record/dataset-ejemplo-1">
+    <foaf:primaryTopic rdf:resource="http://dcat-ap-es.ejemplo.org/dataset/dataset-ejemplo-1"/>
+    <dc:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-01-02T12:00:00+01:00</dc:modified>
+    <dc:conformsTo rdf:resource="http://datos.gob.es/es/documentacion/DCAT-AP-ES"/>
+    <dc:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-01-01T12:00:00+01:00</dc:issued>
+    <adms:status rdf:resource="http://purl.org/adms/status/Completed"/>
+    <dc:title xml:lang="es">Registro del Dataset de ejemplo 1</dc:title>
+    <dc:description xml:lang="es">Registro de metadatos del Dataset de ejemplo 1 del Catálogo de Datos Abiertos</dc:description>
+  </dcat:CatalogRecord>
 
 </rdf:RDF>

--- a/examples/ttl/1.0.0/E_DCAT-AP-ES_full_optional.ttl
+++ b/examples/ttl/1.0.0/E_DCAT-AP-ES_full_optional.ttl
@@ -24,22 +24,8 @@
   dct:license <http://publications.europa.eu/resource/authority/licence/CC_BY_4_0> ;
   dct:spatial <http://datos.gob.es/recurso/sector-publico/territorio/Pais/España> ;
   dcat:catalog <http://dcat-ap-es.ejemplo.org/catalogo_relacionado> ;
-  dcat:record [
-    a dcat:CatalogRecord ;
-    foaf:primaryTopic <http://dcat-ap-es.ejemplo.org/catalogo> ;
-    dct:modified "2021-01-02T12:00:00+01:00"^^xsd:dateTime ;
-    dct:conformsTo <http://datos.gob.es/es/documentacion/DCAT-AP-ES> ;
-    dct:issued "2022-01-01T12:00:00+01:00"^^xsd:dateTime ;
-    adms:status <http://purl.org/adms/status/Completed> ;
-    dct:title "Registro del Catálogo de Datos Abiertos"@es ;
-    dct:description "Registro de metadatos del Catálogo de Datos Abiertos de ejemplo"@es
-  ] ;
-  dct:creator [
-    a foaf:Organization ;
-    foaf:name "Nombre del departamento del organismo" ;
-    dct:identifier "E0DAT0001" ;
-    dct:type <http://purl.org/adms/publishertype/NationalAuthority>
-  ] ;
+  dcat:record <http://dcat-ap-es.ejemplo.org/catalogo/record/dataset-ejemplo-1> ;
+  dct:creator <http://datos.gob.es/recurso/sector-publico/org/Organismo/E0DAT0001> ;
   dct:hasPart <http://dcat-ap-es.ejemplo.org/catalogo-vinculado> ;
   dct:isPartOf <http://dcat-ap-es.ejemplo.org/catalogo-delqueformaparte> ;
   dct:rights <http://dcat-ap-es.ejemplo.org/catalogo/derechos-de-acceso> ;
@@ -91,6 +77,7 @@
 
 <http://dcat-ap-es.ejemplo.org/catalogo-vinculado/distribucion/ejemplo>
   a dcat:Distribution ;
+  dct:title "Distribución de ejemplo en formato CSV"@es ;
   dcat:accessURL <http://dcat-ap-es.ejemplo.org/catalogo-vinculado/files/ejemplo.csv> ;
   dcatap:applicableLegislation <http://data.europa.eu/eli/dir/2007/2/2019-06-26> ;
   dct:description "Descripción de una distribución distribuida de ejemplo"@es ;
@@ -379,3 +366,13 @@
   vcard:hasUID <http://datos.gob.es/recurso/sector-publico/org/Organismo/E0DAT0001> ;
   vcard:hasEmail <mailto:info-contacto@dcat-ap-es.ejemplo.org> ;
   vcard:hasTelephone <tel:.+3491222222> .
+
+<http://dcat-ap-es.ejemplo.org/catalogo/record/dataset-ejemplo-1>
+  a dcat:CatalogRecord ;
+  foaf:primaryTopic <http://dcat-ap-es.ejemplo.org/dataset/dataset-ejemplo-1> ;
+  dct:modified "2025-01-02T12:00:00+01:00"^^xsd:dateTime ;
+  dct:conformsTo <http://datos.gob.es/es/documentacion/DCAT-AP-ES> ;
+  dct:issued "2024-01-01T12:00:00+01:00"^^xsd:dateTime ;
+  adms:status <http://purl.org/adms/status/Completed> ;
+  dct:title "Registro del Dataset de ejemplo 1"@es ;
+  dct:description "Registro de metadatos del Dataset de ejemplo 1 del Catálogo de Datos Abiertos"@es .


### PR DESCRIPTION
Correcciones aplicadas al ejemplo [`E_DCAT-AP-ES_full_optional`](https://github.com/datosgobes/DCAT-AP-ES/blob/main/examples/ttl/1.0.0/E_DCAT-AP-ES_full_optional.ttl) :
1. **CatalogRecord.primaryTopic**: Ahora apunta a `dataset-ejemplo-1` en lugar del catálogo
2. **Catalog.record**: Cambiado de blank node a IRI: `http://dcat-ap-es.ejemplo.org/catalogo/record/dataset-ejemplo-1`
3. **Catalog.creator**: Cambiado de blank node a DIR3 para cumpliri restricciones: `http://datos.gob.es/recurso/sector-publico/org/Organismo/E0DAT0001`
4. **Distribution.title**: Añadido título ausente (warning)
5. **CatalogRecord**: Añadido como recurso independiente al final del archivo