### PR TITLE
feature: relajar validación estricta de xsd:dateTime sin TZ y recomendar su uso

### DIFF
--- a/docs/conventions.en.md
+++ b/docs/conventions.en.md
@@ -243,4 +243,4 @@ To ensure the temporal traceability of resources and their correct tracking, it 
     To validate dates:
     
     1. Verify that the modification date is later than the creation date
-    2. Check that the dates are in the formats defined by the model; dates can be recorded using the standard format: `YYYY-MM-DD` (`xsd:date`), or ISO-8601 datetime with time zone: `YYYY-MM-DDThh:mm:ssTZD` (`xsd:dateTime`), as well as the year: `YYYY` (`xsd:gYear`) or the year and month: `YYYY-MM` (`xsd:gYearMonth`).
+    2. Check that the dates are in the formats defined by the model. Dates can be recorded using the standard format: `YYYY-MM-DD` (`xsd:date`), or an ISO-8601 datetime `YYYY-MM-DDThh:mm:ss` (`xsd:dateTime`). For interoperability it is **recommended** to include a time zone (TZD), e.g. `Z` or `+01:00` (the validator will emit a warning if it is missing). The year `YYYY` (`xsd:gYear`) and the year-month `YYYY-MM` (`xsd:gYearMonth`) are also allowed.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -219,7 +219,7 @@ Para garantizar la trazabilidad temporal de los recursos y su correcto seguimien
     Para validar las fechas:
     
     1. Verificar que la fecha de modificación sea posterior a la de creación
-    2. Comprobar que las fechas estén en los formatos definidos por el modelo, se puede registrar la fecha utilizando el formato estándar: `YYYY-MM-DD` (`xsd:date`), o el [datetime ISO-8601](https://www.w3.org/TR/1998/NOTE-datetime-19980827) con zona horaria: `YYYY-MM-DDThh:mm:ssTZD` (`xsd:dateTime`), así como el año: `YYYY` (`xsd:gYear`) o el año y el mes: `YYYY-MM` (`xsd:gYearMonth`).
+    2. Comprobar que las fechas estén en los formatos definidos por el modelo. Se puede registrar la fecha utilizando el formato estándar: `YYYY-MM-DD` (`xsd:date`), o el [datetime ISO-8601](https://www.w3.org/TR/1998/NOTE-datetime-19980827) `YYYY-MM-DDThh:mm:ss` (`xsd:dateTime`). Para mejorar la interoperabilidad se **recomienda** incluir zona horaria (TZD), por ejemplo `Z` o `+01:00` (el validador emitirá una advertencia si falta). También se admite el año: `YYYY` (`xsd:gYear`) o el año y el mes: `YYYY-MM` (`xsd:gYearMonth`).
 
 ## Especificación de períodos temporales {#general-temporal}
 

--- a/shacl/1.0.0/shacl_common_shapes.ttl
+++ b/shacl/1.0.0/shacl_common_shapes.ttl
@@ -261,6 +261,12 @@ dcatapes:DateOrDateTimeDataTypetConvention
             sh:message "The value must be data typed xsd:dateTime and follow the format YYYY-MM-DDThh:mm:ssTZD."@en ;
         ]
         [
+            sh:datatype xsd:dateTime ;
+            sh:pattern "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]{1,6})?$" ;
+            sh:message "El valor debe ser de tipo xsd:dateTime y seguir el formato YYYY-MM-DDThh:mm:ss (opcionalmente con fracción de segundos)."@es ;
+            sh:message "The value must be data typed xsd:dateTime and follow the format YYYY-MM-DDThh:mm:ss (optionally with fractional seconds)."@en ;
+        ]
+        [
             sh:datatype xsd:date ;
             sh:pattern "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$" ;
             sh:message "El valor debe ser de tipo xsd:date y seguir el formato YYYY-MM-DD."@es ;
@@ -279,6 +285,20 @@ dcatapes:DateOrDateTimeDataTypetConvention
             sh:message "The value must be a valid data typed xsd:gYear and follow the format YYYY."@en ;
         ]
     ) ;
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:severity sh:Warning ;
+        sh:message "El valor es un xsd:dateTime sin zona horaria (TZD). Por interoperabilidad, se recomienda incluir 'Z' o un offset (por ejemplo, +01:00)."@es ;
+        sh:message "The value is an xsd:dateTime without a time zone (TZD). For interoperability, it is recommended to include 'Z' or an offset (e.g., +01:00)."@en ;
+        sh:select """
+            PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+            SELECT $this
+            WHERE {
+                FILTER(datatype($this) = xsd:dateTime)
+                FILTER(regex(str($this), "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])([.][0-9]{1,6})?$") )
+            }
+        """ ;
+    ] ;
     sh:severity sh:Violation .
 
 dcatapes:DurationRestriction


### PR DESCRIPTION
El timezone es opcional en xsd:dateTime, actualmente no pasa el patrón aunque sea un xsd:dateTime perfectamente válido en la forma DateOrDateTimeDataTypetConvention.

Se relaja la validación, aceptando  xsd:dateTime con TZ opcional, pero indicando al usuario que se recomienda incluirla (warning).